### PR TITLE
Add convenience methods to create default-named loggers

### DIFF
--- a/core/src/main/scala/zio/logging/Logger.scala
+++ b/core/src/main/scala/zio/logging/Logger.scala
@@ -8,6 +8,11 @@ import zio.{ FiberRef, UIO, URIO, ZIO }
 trait Logger extends LoggerLike[String]
 object Logger {
 
+  def makeWithName[R](name: String)(logger: (LogContext, => String) => URIO[R, Unit]): URIO[R, Logger] =
+    make { (context, line) =>
+      logger(context.annotate(LogAnnotation.Name, name :: Nil), line)
+    }
+
   /**
    * Constructs a logger provided the specified sink.
    */

--- a/slf4j/src/main/scala/zio/logging/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/Slf4jLogger.scala
@@ -26,6 +26,11 @@ object Slf4jLogger {
       )
     )
 
+  def makeWithName(name: String)(logFormat: (LogContext, => String) => String): UIO[Logging] =
+    make { (context, line) =>
+      logFormat(context.annotate(LogAnnotation.Name, name :: Nil), line)
+    }
+
   def make(logFormat: (LogContext, => String) => String): UIO[Logging] =
     Logging.make { (context, line) =>
       val loggerName = context.get(LogAnnotation.Name) match {


### PR DESCRIPTION
In log level configuration, e.g. logback, one refers to a logger name in order to determine log levels and other properties. It is very useful to be able to determine a global logger name in the moment of its creation. This PR addresses just that, by adding convenience methods to `Logger` and `Slf4jLogger`.