### PR TITLE
Fix name of logger

### DIFF
--- a/core/src/main/scala/zio/logging/LogAnnotation.scala
+++ b/core/src/main/scala/zio/logging/LogAnnotation.scala
@@ -1,5 +1,7 @@
 package zio.logging
 
+import zio.Cause
+
 import scala.reflect.ClassTag
 
 /**
@@ -54,5 +56,22 @@ object LogAnnotation {
    * The `Throwable` annotation keeps track of a throwable.
    */
   val Throwable =
-    LogAnnotation[Option[Throwable]](name = "throwable", initialValue = None, combine = (_, t) => t, _.toString)
+    LogAnnotation[Option[Throwable]](
+      name = "throwable",
+      initialValue = None,
+      combine = (_, t) => t,
+      _.map(_.toString).getOrElse("")
+    )
+
+  /**
+   * The `Cause` annotation keeps track of a Cause.
+   */
+  val Cause =
+    LogAnnotation[Option[Cause[Any]]](
+      name = "cause",
+      initialValue = None,
+      combine = (_, t) => t,
+      _.map(_.toString).getOrElse("")
+    )
+
 }

--- a/core/src/main/scala/zio/logging/Logging.scala
+++ b/core/src/main/scala/zio/logging/Logging.scala
@@ -17,9 +17,15 @@ object Logging {
     make((context, line) =>
       for {
         date       <- currentDateTime.orDie
-        level      = context.get(LogAnnotation.Level)
-        loggerName = LogAnnotation.Name.render(context.get(LogAnnotation.Name))
-        _          <- putStrLn(date.toString + " " + level.render + " " + loggerName + " " + format(context, line))
+        level      = context(LogAnnotation.Level)
+        loggerName = context(LogAnnotation.Name)
+        maybeError = context
+          .get(LogAnnotation.Throwable)
+          .map(Cause.fail)
+          .orElse(context.get(LogAnnotation.Cause))
+          .map(cause => System.lineSeparator() + cause.prettyPrint)
+          .getOrElse("")
+        _ <- putStrLn(date.toString + " " + level + " " + loggerName + " " + format(context, line) + " " + maybeError)
       } yield ()
     )
 

--- a/core/src/main/scala/zio/logging/log.scala
+++ b/core/src/main/scala/zio/logging/log.scala
@@ -20,7 +20,9 @@ object log {
     log(LogLevel.Error)(line)
 
   def error(line: => String, cause: Cause[Any]): ZIO[Logging, Nothing, Unit] =
-    log(LogLevel.Error)(line + System.lineSeparator() + cause.prettyPrint)
+    locally(LogAnnotation.Cause(Some(cause))) {
+      log(LogLevel.Error)(line)
+    }
 
   def info(line: => String): ZIO[Logging, Nothing, Unit] =
     log(LogLevel.Info)(line)
@@ -37,7 +39,9 @@ object log {
     ZIO.access[Logging](_.get.logger)
 
   def throwable(line: => String, t: Throwable): ZIO[Logging, Nothing, Unit] =
-    error(line, Cause.die(t))
+    locally(LogAnnotation.Throwable(Some(t))) {
+      error(line)
+    }
 
   def trace(line: => String): ZIO[Logging, Nothing, Unit] =
     log(LogLevel.Trace)(line)

--- a/examples/src/main/scala/zio/logging/Examples.scala
+++ b/examples/src/main/scala/zio/logging/Examples.scala
@@ -23,7 +23,7 @@ object Examples extends zio.App {
       _     <- fiber.join
       _ <- log.locally(correlationId("1234111")) {
             log.info("info message with correlation id") *>
-              log.throwable("another info message with correlation id", new RuntimeException("error message")).fork
+              log.throwable("this is error", new RuntimeException("error message")).fork
           }
     } yield 1).provideLayer(env)
 }

--- a/examples/src/main/scala/zio/logging/Examples.scala
+++ b/examples/src/main/scala/zio/logging/Examples.scala
@@ -22,9 +22,8 @@ object Examples extends zio.App {
       _     <- log.info("info message without correlation id")
       _     <- fiber.join
       _ <- log.locally(correlationId("1234111")) {
-            log("info message with correlation id") *>
-              log.throwable("this is error.", new RuntimeException("my error")) *>
-              log(LogLevel.Error)("another info message with correlation id").fork
+            log.info("info message with correlation id") *>
+              log.throwable("another info message with correlation id", new RuntimeException("error message")).fork
           }
     } yield 1).provideLayer(env)
 }


### PR DESCRIPTION
this is change how we handle cause and throwable. before we handle this in `log` object but logger should have flexibility how to render error. Moreover that fix logger inference name when slf4j logger is used.