### PR TITLE
Add slf4j with annotations on MDC

### DIFF
--- a/core/src/main/scala/zio/logging/LogContext.scala
+++ b/core/src/main/scala/zio/logging/LogContext.scala
@@ -37,6 +37,10 @@ final case class LogContext private (private val map: Map[LogAnnotation[_], Any]
         map + (annotation -> annotation.combine(self.get(annotation), that.get(annotation)))
     })
   }
+
+  def asStringMap: Map[String, String] = map.map {
+    case (LogAnnotation(name, _, _, render), value) => (name, render(value))
+  }
 }
 
 object LogContext {

--- a/core/src/main/scala/zio/logging/Logging.scala
+++ b/core/src/main/scala/zio/logging/Logging.scala
@@ -20,6 +20,7 @@ object Logging {
         _          <- putStrLn(date.toString + " " + level.render + " " + loggerName + " " + format(context, line))
       } yield ()
     )
+
   def error(cause: Cause[Any]): ZIO[Logging, Nothing, Unit] =
     log(LogLevel.Error)(cause.prettyPrint)
 

--- a/slf4j/src/main/scala/zio/logging/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/Slf4jLogger.scala
@@ -1,13 +1,15 @@
 package zio.logging.slf4j
 
-import org.slf4j.LoggerFactory
+import org.slf4j.{LoggerFactory, MDC}
 import zio.internal.Tracing
 import zio.internal.stacktracer.Tracer
-import zio.internal.stacktracer.ZTraceElement.{ NoLocation, SourceLocation }
+import zio.internal.stacktracer.ZTraceElement.{NoLocation, SourceLocation}
 import zio.internal.stacktracer.impl.AkkaLineNumbersTracer
 import zio.internal.tracing.TracingConfig
 import zio.logging._
-import zio.{ ZIO, ZLayer }
+import zio.{ZIO, ZLayer}
+import scala.collection.JavaConverters._
+
 
 object Slf4jLogger {
 
@@ -47,4 +49,29 @@ object Slf4jLogger {
         }
       )
     }
+
+  def makeWithAnnotationsAsMdc(mdcAnnotations: List[LogAnnotation[_]]): ZLayer[Any, Nothing, Logging] = {
+    val annotationNames = mdcAnnotations.map(_.name)
+
+    Logging.make { (context, line) =>
+      val loggerName = context.get(LogAnnotation.Name) match {
+        case Nil   => classNameForLambda(line).getOrElse("ZIO.defaultLogger")
+        case names => LogAnnotation.Name.render(names)
+      }
+      logger(loggerName).map { slf4jLogger =>
+        MDC.setContextMap(context.asStringMap.filterKeys(annotationNames.contains).asJava)
+        context.get(LogAnnotation.Level).level match {
+          case LogLevel.Off.level => ()
+          case LogLevel.Debug.level => slf4jLogger.debug(line)
+          case LogLevel.Trace.level => slf4jLogger.trace(line)
+          case LogLevel.Info.level => slf4jLogger.info(line)
+          case LogLevel.Warn.level => slf4jLogger.warn(line)
+          case LogLevel.Error.level => slf4jLogger.error(line)
+          case LogLevel.Fatal.level => slf4jLogger.error(line)
+        }
+
+        MDC.clear()
+      }
+    }
+  }
 }


### PR DESCRIPTION
Added an implementation of slf4j logger that puts a defined set of annotations from the LogContext into MDC logging context