### PR TITLE
slf4j logger with annotations on mdc context

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,8 +68,13 @@ lazy val slf4j = project
   .settings(stdSettings("zio-logging-slf4j"))
   .settings(
     libraryDependencies ++= Seq(
-      "org.slf4j" % "slf4j-api" % "1.7.30"
-    )
+      "org.slf4j"            % "slf4j-api"                % "1.7.30",
+      "dev.zio"              %%% "zio-test"               % ZioVersion % Test,
+      "dev.zio"              %%% "zio-test-sbt"           % ZioVersion % Test,
+      "ch.qos.logback"       % "logback-classic"          % "1.2.3" % Test,
+      "net.logstash.logback" % "logstash-logback-encoder" % "6.3" % Test
+    ),
+    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
   )
 
 lazy val jsconsole = project

--- a/build.sbt
+++ b/build.sbt
@@ -126,6 +126,7 @@ lazy val examples = project
   .settings(
     skip in publish := true,
     libraryDependencies ++= Seq(
-      "ch.qos.logback" % "logback-classic" % "1.2.3"
+      "ch.qos.logback"       % "logback-classic"          % "1.2.3",
+      "net.logstash.logback" % "logstash-logback-encoder" % "6.3"
     )
   )

--- a/examples/src/main/resources/logback.xml
+++ b/examples/src/main/resources/logback.xml
@@ -7,7 +7,13 @@
         </layout>
     </appender>
 
+    <appender name="logstash" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
     <root level="debug">
         <appender-ref ref="STDOUT" />
+        <appender-ref ref="logstash" />
     </root>
+
 </configuration>

--- a/examples/src/main/scala/zio/logging/Slf4jMdc.scala
+++ b/examples/src/main/scala/zio/logging/Slf4jMdc.scala
@@ -1,0 +1,34 @@
+package zio.logging
+
+import java.util.UUID
+
+import zio.logging.slf4j.Slf4jLogger
+import zio.clock.Clock
+import zio.{ App, UIO, ZIO }
+import zio.duration._
+
+object Slf4jMdc extends App {
+
+  val userId = LogAnnotation[UUID](
+    name = "user-id",
+    initialValue = UUID.fromString("0-0-0-0-0"),
+    combine = (_, newValue) => newValue,
+    render = _.toString
+  )
+
+  val logLayer = Slf4jLogger.makeWithAnnotationsAsMdc(List(userId))
+  val users    = List.fill(2)(UUID.randomUUID())
+
+  override def run(args: List[String]): ZIO[zio.ZEnv, Nothing, Int] =
+    (for {
+      _             <- log.info("Start...")
+      correlationId <- UIO(Some(UUID.randomUUID()))
+      _ <- ZIO.foreachPar(users) { uId =>
+            log.locally(_.annotate(userId, uId).annotate(LogAnnotation.CorrelationId, correlationId)) {
+              log.info("Starting operation") *>
+                ZIO.sleep(500.millis) *>
+                log.info("Stopping operation")
+            }
+          }
+    } yield 0).provideSomeLayer[Clock](logLayer)
+}

--- a/slf4j/src/main/scala/zio/logging/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/Slf4jLogger.scala
@@ -55,6 +55,9 @@ object Slf4jLogger {
       rootLoggerName = rootLoggerName
     )
 
+  /**
+   * Creates a slf4j logger that puts all the annotations defined in `mdcAnnotations` in the MDC context
+   */
   def makeWithAnnotationsAsMdc(
     mdcAnnotations: List[LogAnnotation[_]],
     logFormat: (LogContext, => String) => String = (_, s) => s,

--- a/slf4j/src/main/scala/zio/logging/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/Slf4jLogger.scala
@@ -9,8 +9,8 @@ import zio.internal.tracing.TracingConfig
 import zio.logging.Logging
 import zio.logging._
 import zio.{ ZIO, ZLayer }
-import scala.collection.JavaConverters._
 
+import scala.jdk.CollectionConverters._
 object Slf4jLogger {
 
   private val tracing = Tracing(Tracer.globallyCached(new AkkaLineNumbersTracer), TracingConfig.enabled)
@@ -69,7 +69,10 @@ object Slf4jLogger {
         }
         logger(loggerName).map {
           slf4jLogger =>
-            MDC.setContextMap(context.renderContext.filterKeys(annotationNames.contains).asJava)
+            val mdc: Map[String, String] = context.renderContext.filter {
+              case (k, _) => annotationNames.contains(k)
+            }
+            MDC.setContextMap(mdc.asJava)
             context.get(LogAnnotation.Level).level match {
               case LogLevel.Off.level   => ()
               case LogLevel.Debug.level => slf4jLogger.debug(line)

--- a/slf4j/src/test/resources/logback-test.xml
+++ b/slf4j/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="zio.logging.slf4j.TestAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} %msg%n</Pattern>
+        </layout>
+    </appender>
+
+    <appender name="logstash" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="logstash" />
+    </root>
+</configuration>

--- a/slf4j/src/test/scala/zio/logging/slf4j/Slf4jLoggerTest.scala
+++ b/slf4j/src/test/scala/zio/logging/slf4j/Slf4jLoggerTest.scala
@@ -1,0 +1,44 @@
+package zio.logging.slf4j
+
+import java.util.UUID
+
+import zio.{ UIO, ULayer }
+import zio.test.DefaultRunnableSpec
+import zio.logging._
+import zio.test._
+import zio.test.Assertion._
+
+import scala.jdk.CollectionConverters._
+
+object Slf4jLoggerTest extends DefaultRunnableSpec {
+
+  val logLayer: ULayer[Logging] =
+    Slf4jLogger.makeWithAnnotationsAsMdc(
+      List(LogAnnotation.CorrelationId, LogAnnotation.Level)
+    )
+
+  def spec =
+    suite("slf4j logger")(
+      testM("test1") {
+        for {
+          uuid1 <- UIO(UUID.randomUUID())
+          uuid2 <- UIO(UUID.randomUUID())
+          _ <- log.locally(_.annotate(LogAnnotation.CorrelationId, Some(uuid1))) {
+                log.info("log stmt 1") *>
+                  log.locally(_.annotate(LogAnnotation.CorrelationId, Some(uuid2))) {
+                    log.info("log stmt 1_1") *>
+                      log.info("log stmt 1_2")
+                  } *>
+                  log.info("log stmt 2")
+              }
+        } yield {
+          val testEvs = TestAppender.events
+          assert(testEvs.size)(equalTo(4)) &&
+          assert(testEvs.map(_.getMessage))(equalTo(List("log stmt 1", "log stmt 1_1", "log stmt 1_2", "log stmt 2"))) &&
+          assert(testEvs.map(_.getMDCPropertyMap.asScala("correlation-id")))(
+            equalTo(List(uuid1.toString, uuid2.toString, uuid2.toString, uuid1.toString))
+          )
+        }
+      }
+    ).provideCustomLayer(logLayer)
+}

--- a/slf4j/src/test/scala/zio/logging/slf4j/TestAppender.scala
+++ b/slf4j/src/test/scala/zio/logging/slf4j/TestAppender.scala
@@ -1,0 +1,29 @@
+package zio.logging.slf4j
+
+import java.util.concurrent.atomic.AtomicReference
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+
+import scala.annotation.tailrec
+
+class TestAppender extends AppenderBase[ILoggingEvent] {
+  override def append(event: ILoggingEvent): Unit =
+    TestAppender.appendEvent(event)
+}
+
+object TestAppender {
+
+  private val logEventsRef: AtomicReference[List[ILoggingEvent]] = new AtomicReference[List[ILoggingEvent]](Nil)
+
+  def reset(): Unit = logEventsRef.set(Nil)
+
+  def events: List[ILoggingEvent] = logEventsRef.get().reverse
+
+  @tailrec
+  def appendEvent(event: ILoggingEvent): Unit = {
+    val old = logEventsRef.get()
+    if (logEventsRef.compareAndSet(old, event :: old)) ()
+    else appendEvent(event)
+  }
+}


### PR DESCRIPTION
Added an implementation of slf4j logger that puts a defined set of annotations from the LogContext into MDC logging context.