### PR TITLE
Make console logger nice and beauty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 import sbtcrossproject.CrossPlugin.autoImport.{ crossProject, CrossType }
 import BuildHelper._
 
+name := "zio-logging"
+
 inThisBuild(
   List(
     organization := "dev.zio",

--- a/core/src/main/scala/zio/logging/LogDatetimeFormatter.scala
+++ b/core/src/main/scala/zio/logging/LogDatetimeFormatter.scala
@@ -1,0 +1,25 @@
+package zio.logging
+
+import java.time.format.{ DateTimeFormatterBuilder, SignStyle }
+import java.time.temporal.ChronoField._
+import java.util.Locale
+
+object LogDatetimeFormatter {
+  val humanReadableDateTimeFormatter = new DateTimeFormatterBuilder()
+    .parseCaseInsensitive()
+    .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+    .appendLiteral('-')
+    .appendValue(MONTH_OF_YEAR, 2)
+    .appendLiteral('-')
+    .appendValue(DAY_OF_MONTH, 2)
+    .appendLiteral(' ')
+    .appendValue(HOUR_OF_DAY, 2)
+    .appendLiteral(':')
+    .appendValue(MINUTE_OF_HOUR, 2)
+    .appendLiteral(':')
+    .appendValue(SECOND_OF_MINUTE, 2)
+    .appendLiteral('.')
+    .appendValue(MILLI_OF_SECOND, 3)
+    .appendOffset("+HHMM", "Z")
+    .toFormatter(Locale.US)
+}

--- a/core/src/main/scala/zio/logging/LogLevel.scala
+++ b/core/src/main/scala/zio/logging/LogLevel.scala
@@ -19,11 +19,11 @@ sealed trait LogLevel { self =>
 // format: off
 object LogLevel {
 // format: on
-  case object Fatal extends LogLevel { val level = 6; val render = "FATAL" }
-  case object Error extends LogLevel { val level = 5; val render = "ERROR" }
-  case object Warn  extends LogLevel { val level = 4; val render = "WARN"  }
-  case object Info  extends LogLevel { val level = 3; val render = "INFO"  }
-  case object Debug extends LogLevel { val level = 2; val render = "DEBUG" }
-  case object Trace extends LogLevel { val level = 1; val render = "TRACE" }
-  case object Off   extends LogLevel { val level = 0; val render = "OFF"   }
+  case object Fatal extends LogLevel { val level = 6; val render = "fatal" }
+  case object Error extends LogLevel { val level = 5; val render = "error" }
+  case object Warn  extends LogLevel { val level = 4; val render = "warn"  }
+  case object Info  extends LogLevel { val level = 3; val render = "info"  }
+  case object Debug extends LogLevel { val level = 2; val render = "debug" }
+  case object Trace extends LogLevel { val level = 1; val render = "trace" }
+  case object Off   extends LogLevel { val level = 0; val render = "off"   }
 }

--- a/core/src/main/scala/zio/logging/LogWriter.scala
+++ b/core/src/main/scala/zio/logging/LogWriter.scala
@@ -1,0 +1,84 @@
+package zio.logging
+
+import java.time.OffsetDateTime
+
+import zio.{ Cause, URIO }
+import zio.clock.{ currentDateTime, Clock }
+import zio.console.{ putStrLn, Console }
+import zio.logging.LogDatetimeFormatter.humanReadableDateTimeFormatter
+import zio.logging.LogLevel._
+
+import scala.io.AnsiColor._
+
+trait LogWriter[R] {
+  def writeLog(context: LogContext, line: => String): URIO[R, Unit]
+}
+
+object LogWriter {
+
+  private val NL = System.lineSeparator()
+
+  type LineFormatter = (LogContext, => String) => String
+
+  case class SimpleConsoleLogWriter(format: LineFormatter = (_, s) => s) extends LogWriter[Console with Clock] {
+    override def writeLog(context: LogContext, line: => String): URIO[Console with Clock, Unit] =
+      for {
+        date      <- currentDateTime.orDie
+        level      = context(LogAnnotation.Level)
+        loggerName = context(LogAnnotation.Name)
+        maybeError = context
+                       .get(LogAnnotation.Throwable)
+                       .map(Cause.fail)
+                       .orElse(context.get(LogAnnotation.Cause))
+                       .map(cause => NL + cause.prettyPrint)
+                       .getOrElse("")
+        _         <- putStrLn(
+                       humanReadableDateTimeFormatter
+                         .format(date) + " " + level + " " + loggerName + " " + format(context, line) + " " + maybeError
+                     )
+      } yield ()
+  }
+
+  case class ColoredLogWriter(lineFormat: LineFormatter = (_, s) => s) extends LogWriter[Console with Clock] {
+    private def withColor(color: String, s: String): String = s"$color$s$RESET"
+
+    private def highlightLog(level: LogLevel, message: String): String = {
+      val color = level match {
+        case Error => RED
+        case Warn  => YELLOW
+        case Info  => CYAN
+        case Debug => GREEN
+        case Trace => MAGENTA
+        case _     => RESET
+      }
+      withColor(color, message)
+    }
+
+    private def format(
+      line: => String,
+      time: OffsetDateTime,
+      level: LogLevel,
+      loggerName: String,
+      maybeError: Option[String]
+    ): String = {
+      val logTag  = highlightLog(level, level.render)
+      val logTime = withColor(BLUE, humanReadableDateTimeFormatter.format(time))
+      val logMsg  =
+        f"$logTime $logTag%14s [${withColor(WHITE, loggerName)}] ${highlightLog(level, line)}"
+      maybeError.fold(logMsg)(err => s"$logMsg$NL${highlightLog(level, err)}")
+    }
+
+    override def writeLog(context: LogContext, line: => String): URIO[Console with Clock, Unit] =
+      for {
+        date      <- currentDateTime.orDie
+        level      = context.get(LogAnnotation.Level)
+        loggerName = context(LogAnnotation.Name)
+        maybeError = context
+                       .get(LogAnnotation.Throwable)
+                       .map(Cause.fail)
+                       .orElse(context.get(LogAnnotation.Cause))
+                       .map(_.prettyPrint)
+        _         <- putStrLn(format(lineFormat(context, line), date, level, loggerName, maybeError))
+      } yield ()
+  }
+}


### PR DESCRIPTION
AddedColoredLogWriter using ANSI colors to make logs readable.
Make it as default console logger.
Moved previous default console writer to SimpleConsoleLogWriter.
Also changed logLevel render names  lowercase to not yelling at me.

Before:
<img width="1028" alt="console_logging_simple" src="https://user-images.githubusercontent.com/91045/83311120-f3b61c80-a216-11ea-889b-683f25ef619a.png">

After:
<img width="1024" alt="console_logging_ansi_colored" src="https://user-images.githubusercontent.com/91045/83311142-04669280-a217-11ea-9d3f-0ddcbeb8123a.png">