### PR TITLE
Lazy Logging

### DIFF
--- a/core/src/main/scala/zio/logging/Logger.scala
+++ b/core/src/main/scala/zio/logging/Logger.scala
@@ -24,10 +24,20 @@ trait Logger[-A] { self =>
     self.log(LogLevel.Debug)(line)
 
   /**
+   * Evaluates the specified element based on the LogLevel set and logs at the debug level
+   */
+  def debug(line: UIO[A]): UIO[Unit] = line >>= debug
+
+  /**
    * Logs the specified element at the error level.
    */
   def error(line: => A): UIO[Unit] =
     self.log(LogLevel.Error)(line)
+
+  /**
+   * Evaluates the specified element based on the LogLevel set and logs at the error level
+   */
+  def error(line: UIO[A]): UIO[Unit] = line >>= error
 
   /**
    * Logs the specified element at the error level with cause.
@@ -36,6 +46,11 @@ trait Logger[-A] { self =>
     self.locally(LogAnnotation.Cause(Some(cause))) {
       self.log(LogLevel.Error)(line)
     }
+
+  /**
+   * Evaluates the specified element based on the LogLevel set and logs at the error level
+   */
+  def error(line: UIO[A], cause: Cause[Any]): UIO[Unit] = line.flatMap(l => error(l, cause))
 
   /**
    * Derives a new logger from this one, by applying the specified decorator
@@ -56,6 +71,11 @@ trait Logger[-A] { self =>
    */
   def info(line: => A): UIO[Unit] =
     self.log(LogLevel.Info)(line)
+
+  /**
+   * Evaluates the specified element based on the LogLevel set and logs at the info level
+   */
+  def info(line: UIO[A]): UIO[Unit] = line >>= info
 
   /**
    * Modifies the log context in the scope of the specified effect.
@@ -112,8 +132,18 @@ trait Logger[-A] { self =>
     self.log(LogLevel.Trace)(line)
 
   /**
+   * Evaluates the specified element based on the LogLevel set and logs at the trace level
+   */
+  def trace(line: UIO[A]): UIO[Unit] = line >>= trace
+
+  /**
    * Logs the specified element at the warn level.
    */
   def warn(line: => A) =
     self.log(LogLevel.Warn)(line)
+
+  /**
+   * Evaluates the specified element based on the LogLevel set and logs at the warn level
+   */
+  def warn(line: UIO[A]): UIO[Unit] = line >>= warn
 }

--- a/core/src/main/scala/zio/logging/Logger.scala
+++ b/core/src/main/scala/zio/logging/Logger.scala
@@ -26,7 +26,7 @@ trait Logger[-A] { self =>
   /**
    * Evaluates the specified element based on the LogLevel set and logs at the debug level
    */
-  def debug(line: UIO[A]): UIO[Unit] = line >>= debug
+  def debugM[R, E](line: ZIO[R, E, A]): ZIO[R, E, Unit] = line >>= (debug(_))
 
   /**
    * Logs the specified element at the error level.
@@ -37,7 +37,7 @@ trait Logger[-A] { self =>
   /**
    * Evaluates the specified element based on the LogLevel set and logs at the error level
    */
-  def error(line: UIO[A]): UIO[Unit] = line >>= error
+  def errorM[R, E](line: ZIO[R, E, A]): ZIO[R, E, Unit] = line >>= (error(_))
 
   /**
    * Logs the specified element at the error level with cause.
@@ -50,7 +50,7 @@ trait Logger[-A] { self =>
   /**
    * Evaluates the specified element based on the LogLevel set and logs at the error level
    */
-  def error(line: UIO[A], cause: Cause[Any]): UIO[Unit] = line.flatMap(l => error(l, cause))
+  def errorM[R, E](line: ZIO[R, E, A], cause: Cause[Any]): ZIO[R, E, Unit] = line.flatMap(l => error(l, cause))
 
   /**
    * Derives a new logger from this one, by applying the specified decorator
@@ -75,7 +75,7 @@ trait Logger[-A] { self =>
   /**
    * Evaluates the specified element based on the LogLevel set and logs at the info level
    */
-  def info(line: UIO[A]): UIO[Unit] = line >>= info
+  def infoM[R, E](line: ZIO[R, E, A]): ZIO[R, E, Unit] = line >>= (info(_))
 
   /**
    * Modifies the log context in the scope of the specified effect.
@@ -134,7 +134,7 @@ trait Logger[-A] { self =>
   /**
    * Evaluates the specified element based on the LogLevel set and logs at the trace level
    */
-  def trace(line: UIO[A]): UIO[Unit] = line >>= trace
+  def traceM[R, E](line: ZIO[R, E, A]): ZIO[R, E, Unit] = line >>= (trace(_))
 
   /**
    * Logs the specified element at the warn level.
@@ -145,5 +145,5 @@ trait Logger[-A] { self =>
   /**
    * Evaluates the specified element based on the LogLevel set and logs at the warn level
    */
-  def warn(line: UIO[A]): UIO[Unit] = line >>= warn
+  def warnM[R, E](line: ZIO[R, E, A]): ZIO[R, E, Unit] = line >>= (warn(_))
 }


### PR DESCRIPTION
## Feature
A lot of times, an effect should be executed only for logging purposes. This can cause performance issues even when the logging is turned off since the effect will still get evaluated.

## Current
```scala
for {
  f <- foo
  b <- bar
  _ <- log.debug(b) // b is needed only for logging purposes
} yield f
```

## Proposed
```scala
for {
  f <- foo
  _ <- log.debug(bar) // bar get's evaluated only when LogLevel is "debug"
} yield f
```

