### PR TITLE
Add async file logging and more features to file appender

### DIFF
--- a/core/src/main/scala/zio/logging/LogWriter.scala
+++ b/core/src/main/scala/zio/logging/LogWriter.scala
@@ -1,6 +1,6 @@
 package zio.logging
 
-import java.io.{ BufferedWriter, FileWriter, Writer }
+import java.io.{ BufferedWriter, FileOutputStream, OutputStreamWriter, Writer }
 import java.nio.charset.Charset
 import java.nio.file.Path
 
@@ -10,9 +10,12 @@ private[logging] class LogWriter(
   autoFlushBatchSize: Int,
   bufferedIOSize: Option[Int]
 ) extends Writer {
-  private val writer: Writer = bufferedIOSize match {
-    case Some(bufferSize) => new BufferedWriter(new FileWriter(destination.toFile, charset), bufferSize)
-    case None             => new FileWriter(destination.toFile, charset)
+  private val writer: Writer = {
+    val output = new OutputStreamWriter(new FileOutputStream(destination.toFile), charset)
+    bufferedIOSize match {
+      case Some(bufferSize) => new BufferedWriter(output, bufferSize)
+      case None             => output
+    }
   }
 
   private var entriesWritten: Long = 0

--- a/core/src/main/scala/zio/logging/LogWriter.scala
+++ b/core/src/main/scala/zio/logging/LogWriter.scala
@@ -1,0 +1,36 @@
+package zio.logging
+
+import java.io.{ BufferedWriter, FileWriter, Writer }
+import java.nio.charset.Charset
+import java.nio.file.Path
+
+private[logging] class LogWriter(
+  destination: Path,
+  charset: Charset,
+  autoFlushBatchSize: Int,
+  bufferedIOSize: Option[Int]
+) extends Writer {
+  private val writer: Writer = bufferedIOSize match {
+    case Some(bufferSize) => new BufferedWriter(new FileWriter(destination.toFile, charset), bufferSize)
+    case None             => new FileWriter(destination.toFile, charset)
+  }
+
+  private var entriesWritten: Long = 0
+
+  def write(buffer: Array[Char], offset: Int, length: Int): Unit =
+    writer.write(buffer, offset, length)
+
+  def writeln(line: String): Unit = {
+    writer.write(line)
+    writer.write(System.lineSeparator)
+
+    entriesWritten += 1
+
+    if (entriesWritten % autoFlushBatchSize == 0)
+      writer.flush()
+  }
+
+  def flush(): Unit = writer.flush()
+
+  def close(): Unit = writer.close()
+}


### PR DESCRIPTION
I noticed there's a `file` LogAppender and I wanted to use it, but it didn't have a constructor in `Logging`. It looks like it was still a work in progress. Here's my attempt at finishing it, as well as adding an async file logger which does two things:
- Return to the caller as quickly as possible (the "write" is just an enqueuing operation)
- Makes flushing more efficient by batching them (the batch size is configurable)

A few other things:
- `LogAppender.file` wasn't inserting a newline at the end unlike `LogAppender.console`. This means the output would be on a single line. And since `BufferedWriter` flushes on newline, flushing wasn't happening properly.
- I added LogLevel filtering to both `file` and `fileAsync`
- I changed the filename param to be a `Path` to be more consistent with ZIO (like ZStream), and because it makes it more obvious that it's a path and not necessarily just a filename. And specific types are generally better than String for catching mistakes earlier.

I didn't quite address one other issue that was bothering me because I figured a discussion about it would be better before making any changes... but the usage of `ZIO.effectTotal` for file writes doesn't seem desirable. I understand the decision came from not wanting to make `LogAppender.write` deal with failures, but having a Logger fail with defects is incredibly difficult to handle. If I don't want crashes due to logging I basically have sandbox every logging statement, which means managing my own class full of helper methods. It would duplicate a lot of what the `Logging` object does.

I think there are other ways to handle that. Perhaps an ADT which specifies the error handling strategy, like: `Die`, `Ignore`, and `Warn`.

I was thinking `Warn` would be something like: if an exception happens during file writing, it would print a warning to `System.err` and then give up with file I/O without crashing the program.