### PR TITLE
Explicit type annotations to public members

### DIFF
--- a/core/src/main/scala/zio/logging/LogLevel.scala
+++ b/core/src/main/scala/zio/logging/LogLevel.scala
@@ -7,10 +7,10 @@ sealed trait LogLevel { self =>
   def render: String
   def level: Int
 
-  def >(that: LogLevel)  = self.level > that.level
-  def >=(that: LogLevel) = self.level >= that.level
-  def <(that: LogLevel)  = self.level < that.level
-  def <=(that: LogLevel) = self.level <= that.level
+  def >(that: LogLevel): Boolean  = self.level > that.level
+  def >=(that: LogLevel): Boolean = self.level >= that.level
+  def <(that: LogLevel): Boolean  = self.level < that.level
+  def <=(that: LogLevel): Boolean = self.level <= that.level
 
   def max(that: LogLevel): LogLevel = if (self < that) that else self
 

--- a/core/src/main/scala/zio/logging/Logger.scala
+++ b/core/src/main/scala/zio/logging/Logger.scala
@@ -43,7 +43,7 @@ trait Logger[-A] { self =>
   /**
    * Logs the specified element at the error level with cause.
    */
-  def error(line: => A, cause: Cause[Any]) =
+  def error(line: => A, cause: Cause[Any]): UIO[Unit] =
     self.locally(LogAnnotation.Cause(Some(cause))) {
       self.log(LogLevel.Error)(line)
     }
@@ -141,7 +141,7 @@ trait Logger[-A] { self =>
   /**
    * Logs the specified element at the error level with exception.
    */
-  def throwable(line: => A, t: Throwable) =
+  def throwable(line: => A, t: Throwable): UIO[Unit] =
     self.locally(LogAnnotation.Throwable(Some(t))) {
       self.error(line)
     }
@@ -160,7 +160,7 @@ trait Logger[-A] { self =>
   /**
    * Logs the specified element at the warn level.
    */
-  def warn(line: => A) =
+  def warn(line: => A): UIO[Unit] =
     self.log(LogLevel.Warn)(line)
 
   /**


### PR DESCRIPTION
To stay consistent with the other ZIO projects. Also it makes reading the signatures easier. For example, you can easily see the ZLayer can fail with a Throwable and so on without looking at the implementation itself.