### PR TITLE
Add an opt-out makeWithAnnotationsAsMdc variant

### DIFF
--- a/slf4j/src/main/scala/zio/logging/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/Slf4jLogger.scala
@@ -75,11 +75,32 @@ object Slf4jLogger {
    * Creates a slf4j logger that puts all the annotations defined in `mdcAnnotations` in the MDC context
    */
   def makeWithAnnotationsAsMdc(
-    mdcAnnotations: List[LogAnnotation[_]],
+                                mdcAnnotations: List[LogAnnotation[_]],
+                                logFormat: (LogContext, => String) => String = (_, s) => s
+                              ): ULayer[Logging] = {
+    val annotationNames = mdcAnnotations.map(_.name).toSet
+    val filter = (renderContext: Map[String, String]) => renderContext.filterKeys(annotationNames)
+    makeWithAnnotationsAsMdcWithFilter(filter, logFormat)
+  }
+
+  /**
+   * Creates a slf4j logger that puts all the annotations in the MDC context unless excludes by the names that are
+   * defined in `mdcAnnotations` in the MDC context
+   */
+  def makeWithAllAnnotationsAsMdc(
+                                  excludeMdcAnnotations: Set[String] = Set.empty,
+                                  logFormat: (LogContext, => String) => String = (_, s) => s
+                                ): ULayer[Logging] = {
+    val filter = (renderContext: Map[String, String]) => renderContext.filterNot{case (k, _) =>
+      excludeMdcAnnotations.contains(k)
+    }
+    makeWithAnnotationsAsMdcWithFilter(filter, logFormat)
+  }
+
+  def makeWithAnnotationsAsMdcWithFilter(
+    filter: Map[String, String] => Map[String, String],
     logFormat: (LogContext, => String) => String = (_, s) => s
   ): ULayer[Logging] = {
-    val annotationNames = mdcAnnotations.map(_.name)
-
     LogAppender.make[Any, String](
       LogFormat.fromFunction(logFormat),
       (context, line) => {
@@ -87,20 +108,22 @@ object Slf4jLogger {
         logger(loggerName).map { slf4jLogger =>
           val maybeThrowable = context.get(LogAnnotation.Throwable).orNull
 
-          val mdc: Map[String, String] = context.renderContext.filter { case (k, _) =>
-            annotationNames.contains(k)
-          }
+          val mdc: Map[String, String] = filter(context.renderContext)
+          val previous = Option(MDC.getCopyOfContextMap()).getOrElse(Map.empty[String, String].asJava)
           MDC.setContextMap(mdc.asJava)
-          context.get(LogAnnotation.Level).level match {
-            case LogLevel.Off.level   => ()
-            case LogLevel.Debug.level => slf4jLogger.debug(line, maybeThrowable)
-            case LogLevel.Trace.level => slf4jLogger.trace(line, maybeThrowable)
-            case LogLevel.Info.level  => slf4jLogger.info(line, maybeThrowable)
-            case LogLevel.Warn.level  => slf4jLogger.warn(line, maybeThrowable)
-            case LogLevel.Error.level => slf4jLogger.error(line, maybeThrowable)
-            case LogLevel.Fatal.level => slf4jLogger.error(line, maybeThrowable)
+          try {
+            context.get(LogAnnotation.Level).level match {
+              case LogLevel.Off.level => ()
+              case LogLevel.Debug.level => slf4jLogger.debug(line, maybeThrowable)
+              case LogLevel.Trace.level => slf4jLogger.trace(line, maybeThrowable)
+              case LogLevel.Info.level => slf4jLogger.info(line, maybeThrowable)
+              case LogLevel.Warn.level => slf4jLogger.warn(line, maybeThrowable)
+              case LogLevel.Error.level => slf4jLogger.error(line, maybeThrowable)
+              case LogLevel.Fatal.level => slf4jLogger.error(line, maybeThrowable)
+            }
+          } finally {
+            MDC.setContextMap(previous)
           }
-          MDC.clear()
         }
       }
     ) >>> withLoggerNameFromLine[String] >>> Logging.make

--- a/slf4j/src/main/scala/zio/logging/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/Slf4jLogger.scala
@@ -79,7 +79,10 @@ object Slf4jLogger {
     logFormat: (LogContext, => String) => String = (_, s) => s
   ): ULayer[Logging] = {
     val annotationNames = mdcAnnotations.map(_.name).toSet
-    val filter          = (renderContext: Map[String, String]) => renderContext.filterKeys(annotationNames)
+    val filter          = (renderContext: Map[String, String]) =>
+      renderContext.filter { case (k, _) =>
+        annotationNames.contains(k)
+      }
     makeWithAnnotationsAsMdcWithFilter(filter, logFormat)
   }
 

--- a/slf4j/src/test/scala/zio/logging/slf4j/Slf4jLoggerTest.scala
+++ b/slf4j/src/test/scala/zio/logging/slf4j/Slf4jLoggerTest.scala
@@ -2,27 +2,34 @@ package zio.logging.slf4j
 
 import java.util.UUID
 
-import zio.{ UIO, ULayer }
+import zio.{UIO, ULayer}
 import zio.test.DefaultRunnableSpec
 import zio.logging._
 import zio.test._
 import zio.test.Assertion._
+import zio.test.TestAspect.sequential
 
 import scala.jdk.CollectionConverters._
 
 object Slf4jLoggerTest extends DefaultRunnableSpec {
 
   val uuid1                     = UUID.randomUUID()
-  val logLayer: ULayer[Logging] =
+  val logLayerOptIn: ULayer[Logging] =
     Slf4jLogger.makeWithAnnotationsAsMdc(
       mdcAnnotations = List(LogAnnotation.CorrelationId, LogAnnotation.Level)
     ) >>> Logging.withContext(LogContext.empty.annotate(LogAnnotation.CorrelationId, Some(uuid1)))
 
+  val logLayerOptOut: ULayer[Logging] =
+    Slf4jLogger.makeWithAllAnnotationsAsMdc(Set(LogAnnotation.Level.name)) >>>
+      Logging.withContext(LogContext.empty.annotate(LogAnnotation.CorrelationId, Some(uuid1)))
+
   def spec =
     suite("slf4j logger")(
-      testM("test1") {
+
+      testM("test with opt in annotations") {
         for {
           uuid2 <- UIO(UUID.randomUUID())
+          _     =  TestAppender.reset()
           _     <- log.info("log stmt 1") *>
                      log.locally(_.annotate(LogAnnotation.CorrelationId, Some(uuid2))) {
                        log.info("log stmt 1_1") *>
@@ -42,6 +49,35 @@ object Slf4jLoggerTest extends DefaultRunnableSpec {
             equalTo(List(uuid1.toString, uuid2.toString, uuid2.toString, uuid1.toString))
           )
         }
-      }
-    ).provideCustomLayer(logLayer)
+      }.provideCustomLayer(logLayerOptIn),
+
+      testM("test with opt-out annotations") {
+        for {
+          uuid2 <- UIO(UUID.randomUUID())
+          _     =  TestAppender.reset()
+          _     <- log.info("log stmt 1") *>
+            log.locally(_.annotate(LogAnnotation.CorrelationId, Some(uuid2))) {
+              log.info("log stmt 1_1") *>
+                log.info("log stmt 1_2")
+            } *>
+            log.info("log stmt 2")
+        } yield {
+          val testEvs = TestAppender.events
+          assert(testEvs.size)(equalTo(4)) &&
+            assert(testEvs.map(_.getMessage))(
+              equalTo(List("log stmt 1", "log stmt 1_1", "log stmt 1_2", "log stmt 2"))
+            ) &&
+            assert(testEvs.map(_.getLoggerName).map(_.substring(0, 34)).distinct)(
+              equalTo(List("zio.logging.slf4j.Slf4jLoggerTest$"))
+            ) &&
+            assert(testEvs.map(_.getMDCPropertyMap.asScala("correlation-id")))(
+              equalTo(List(uuid1.toString, uuid2.toString, uuid2.toString, uuid1.toString))
+            ) &&
+            assert(testEvs.map(_.getMDCPropertyMap.asScala.get(LogAnnotation.Level.name)))(
+              equalTo(List(None, None, None, None))
+            )
+        }
+      }.provideCustomLayer(logLayerOptOut)
+
+    ) @@ sequential
 }

--- a/slf4j/src/test/scala/zio/logging/slf4j/Slf4jLoggerTest.scala
+++ b/slf4j/src/test/scala/zio/logging/slf4j/Slf4jLoggerTest.scala
@@ -2,7 +2,7 @@ package zio.logging.slf4j
 
 import java.util.UUID
 
-import zio.{UIO, ULayer}
+import zio.{ UIO, ULayer }
 import zio.test.DefaultRunnableSpec
 import zio.logging._
 import zio.test._
@@ -13,7 +13,7 @@ import scala.jdk.CollectionConverters._
 
 object Slf4jLoggerTest extends DefaultRunnableSpec {
 
-  val uuid1                     = UUID.randomUUID()
+  val uuid1                          = UUID.randomUUID()
   val logLayerOptIn: ULayer[Logging] =
     Slf4jLogger.makeWithAnnotationsAsMdc(
       mdcAnnotations = List(LogAnnotation.CorrelationId, LogAnnotation.Level)
@@ -25,11 +25,10 @@ object Slf4jLoggerTest extends DefaultRunnableSpec {
 
   def spec =
     suite("slf4j logger")(
-
       testM("test with opt in annotations") {
         for {
           uuid2 <- UIO(UUID.randomUUID())
-          _     =  TestAppender.reset()
+          _      = TestAppender.reset()
           _     <- log.info("log stmt 1") *>
                      log.locally(_.annotate(LogAnnotation.CorrelationId, Some(uuid2))) {
                        log.info("log stmt 1_1") *>
@@ -50,34 +49,32 @@ object Slf4jLoggerTest extends DefaultRunnableSpec {
           )
         }
       }.provideCustomLayer(logLayerOptIn),
-
       testM("test with opt-out annotations") {
         for {
           uuid2 <- UIO(UUID.randomUUID())
-          _     =  TestAppender.reset()
+          _      = TestAppender.reset()
           _     <- log.info("log stmt 1") *>
-            log.locally(_.annotate(LogAnnotation.CorrelationId, Some(uuid2))) {
-              log.info("log stmt 1_1") *>
-                log.info("log stmt 1_2")
-            } *>
-            log.info("log stmt 2")
+                     log.locally(_.annotate(LogAnnotation.CorrelationId, Some(uuid2))) {
+                       log.info("log stmt 1_1") *>
+                         log.info("log stmt 1_2")
+                     } *>
+                     log.info("log stmt 2")
         } yield {
           val testEvs = TestAppender.events
           assert(testEvs.size)(equalTo(4)) &&
-            assert(testEvs.map(_.getMessage))(
-              equalTo(List("log stmt 1", "log stmt 1_1", "log stmt 1_2", "log stmt 2"))
-            ) &&
-            assert(testEvs.map(_.getLoggerName).map(_.substring(0, 34)).distinct)(
-              equalTo(List("zio.logging.slf4j.Slf4jLoggerTest$"))
-            ) &&
-            assert(testEvs.map(_.getMDCPropertyMap.asScala("correlation-id")))(
-              equalTo(List(uuid1.toString, uuid2.toString, uuid2.toString, uuid1.toString))
-            ) &&
-            assert(testEvs.map(_.getMDCPropertyMap.asScala.get(LogAnnotation.Level.name)))(
-              equalTo(List(None, None, None, None))
-            )
+          assert(testEvs.map(_.getMessage))(
+            equalTo(List("log stmt 1", "log stmt 1_1", "log stmt 1_2", "log stmt 2"))
+          ) &&
+          assert(testEvs.map(_.getLoggerName).map(_.substring(0, 34)).distinct)(
+            equalTo(List("zio.logging.slf4j.Slf4jLoggerTest$"))
+          ) &&
+          assert(testEvs.map(_.getMDCPropertyMap.asScala("correlation-id")))(
+            equalTo(List(uuid1.toString, uuid2.toString, uuid2.toString, uuid1.toString))
+          ) &&
+          assert(testEvs.map(_.getMDCPropertyMap.asScala.get(LogAnnotation.Level.name)))(
+            equalTo(List(None, None, None, None))
+          )
         }
       }.provideCustomLayer(logLayerOptOut)
-
     ) @@ sequential
 }


### PR DESCRIPTION
Currently makeWithAnnotationsAsMdc is opt-in. You need to specify all LogAnnotations that should be output as MDC beforehand. This change creates a variant where all LogAnnotations will be output in the MDC unless opted-out by an exclusion list.