### PR TITLE
Slf4j bridge

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,12 +82,15 @@ lazy val slf4j = project
 
 lazy val slf4jBridge = project
   .in(file("slf4j-bridge"))
-  .dependsOn(coreJVM)
+  .dependsOn(coreJVM % "compile->compile;test->test")
   .settings(stdSettings("zio-logging-slf4j-bridge"))
   .settings(
     libraryDependencies ++= Seq(
-      "org.slf4j" % "slf4j-api" % slf4jVersion
-    )
+      "org.slf4j" % "slf4j-api"    % slf4jVersion,
+      "dev.zio"  %% "zio-test"     % ZioVersion % Test,
+      "dev.zio"  %% "zio-test-sbt" % ZioVersion % Test
+    ),
+    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
   )
 
 lazy val jsconsole = project

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ ThisBuild / publishTo := sonatypePublishToBundle.value
 
 val ZioVersion           = "1.0.3"
 val scalaJavaTimeVersion = "2.0.0-RC5"
+val slf4jVersion         = "1.7.30"
 
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
@@ -70,13 +71,23 @@ lazy val slf4j = project
   .settings(stdSettings("zio-logging-slf4j"))
   .settings(
     libraryDependencies ++= Seq(
-      "org.slf4j"            % "slf4j-api"                % "1.7.30",
+      "org.slf4j"            % "slf4j-api"                % slf4jVersion,
       "dev.zio"            %%% "zio-test"                 % ZioVersion % Test,
       "dev.zio"            %%% "zio-test-sbt"             % ZioVersion % Test,
       "ch.qos.logback"       % "logback-classic"          % "1.2.3"    % Test,
       "net.logstash.logback" % "logstash-logback-encoder" % "6.5"      % Test
     ),
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
+  )
+
+lazy val slf4jBridge = project
+  .in(file("slf4j-bridge"))
+  .dependsOn(coreJVM)
+  .settings(stdSettings("zio-logging-slf4j-bridge"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.slf4j" % "slf4j-api" % slf4jVersion
+    )
   )
 
 lazy val jsconsole = project

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -269,4 +269,18 @@ val loggerLayer = HTTPLogger.make("http://localhost:9000/event/collect")((contex
 
 ```
 
+### SLF4j bridge
+It is possible to use `zio-logging` for SLF4j loggers, usually third-party non-ZIO libraries. To do so, import
+the `zio-logging-slf4j-bridge` module:
 
+```scala
+libraryDependencies += "dev.zio" %% "zio-logging-slf4j-bridge" % version
+```
+
+and use the `bindSlf4jBridge` layer when setting up logging:
+
+```scala
+import zio.logging.slf4j.bridge.bindSlf4jBridge
+
+val env = Logging.consoleErr() >>> bindSlf4jBridge
+```

--- a/slf4j-bridge/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/slf4j-bridge/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -1,0 +1,47 @@
+package org.slf4j.impl;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.spi.LoggerFactoryBinder;
+
+public class StaticLoggerBinder implements LoggerFactoryBinder {
+    /**
+     * The unique instance of this class.
+     */
+    private static final StaticLoggerBinder SINGLETON = new StaticLoggerBinder();
+
+    /**
+     * Return the singleton of this class.
+     *
+     * @return the StaticLoggerBinder singleton
+     */
+    public static final StaticLoggerBinder getSingleton() {
+        return SINGLETON;
+    }
+
+    /**
+     * Declare the version of the SLF4J API this implementation is compiled against.
+     * The value of this field is modified with each major release.
+     */
+    // to avoid constant folding by the compiler, this field must *not* be final
+    public static String REQUESTED_API_VERSION = "1.6.99"; // !final
+
+    private static final String loggerFactoryClassStr = ZioLoggerFactory.class.getName();
+
+    /**
+     * The ILoggerFactory instance returned by the {@link #getLoggerFactory}
+     * method should always be the same object
+     */
+    private final ILoggerFactory loggerFactory;
+
+    private StaticLoggerBinder() {
+        loggerFactory = new ZioLoggerFactory();
+    }
+
+    public ILoggerFactory getLoggerFactory() {
+        return loggerFactory;
+    }
+
+    public String getLoggerFactoryClassStr() {
+        return loggerFactoryClassStr;
+    }
+}

--- a/slf4j-bridge/src/main/scala/org/slf4j/impl/StaticMDCBinder.scala
+++ b/slf4j-bridge/src/main/scala/org/slf4j/impl/StaticMDCBinder.scala
@@ -1,0 +1,15 @@
+package org.slf4j.impl
+
+import org.slf4j.helpers.BasicMDCAdapter
+import org.slf4j.spi.MDCAdapter
+
+class StaticMDCBinder {
+  def getMDCA(): MDCAdapter = StaticMDCBinder.singleton
+
+  def getMDCAdapterClassStr(): String = StaticMDCBinder.className
+}
+
+object StaticMDCBinder {
+  private val singleton: MDCAdapter = new BasicMDCAdapter
+  private val className: String = classOf[BasicMDCAdapter].getName
+}

--- a/slf4j-bridge/src/main/scala/org/slf4j/impl/StaticMarkerBinder.scala
+++ b/slf4j-bridge/src/main/scala/org/slf4j/impl/StaticMarkerBinder.scala
@@ -1,0 +1,15 @@
+package org.slf4j.impl
+
+import org.slf4j.IMarkerFactory
+import org.slf4j.helpers.BasicMarkerFactory
+import org.slf4j.spi.MarkerFactoryBinder
+
+class StaticMarkerBinder extends MarkerFactoryBinder {
+  override def getMarkerFactory: IMarkerFactory = StaticMarkerBinder.singleton
+  override def getMarkerFactoryClassStr: String = StaticMarkerBinder.className
+}
+
+object StaticMarkerBinder {
+  private val singleton = new BasicMarkerFactory
+  private val className = classOf[BasicMarkerFactory].getName
+}

--- a/slf4j-bridge/src/main/scala/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala/org/slf4j/impl/ZioLogger.scala
@@ -1,0 +1,118 @@
+package org.slf4j.impl
+
+import org.slf4j.helpers.MarkerIgnoringBase
+import zio.ZIO
+import zio.logging.{ log, LogAnnotation, Logging }
+
+class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringBase {
+  private val nameList = name.split('.').toList
+  private def run(f: ZIO[Logging, Nothing, Unit]): Unit =
+    factory.run {
+      log.locally(LogAnnotation.Name(nameList))(f)
+    }
+
+  override def isTraceEnabled: Boolean = true
+
+  override def trace(msg: String): Unit =
+    run(log.trace(msg))
+
+  override def trace(format: String, arg: Any): Unit =
+    run(log.trace(String.format(format, arg)))
+
+  override def trace(format: String, arg1: Any, arg2: Any): Unit =
+    run(log.trace(String.format(format, arg1, arg2)))
+
+  override def trace(format: String, arguments: Any*): Unit =
+    run(log.trace(String.format(format, arguments: _*)))
+
+  override def trace(msg: String, t: Throwable): Unit =
+    run(
+      log.locally(LogAnnotation.Throwable(Some(t))) {
+        log.trace(msg)
+      }
+    )
+
+  override def isDebugEnabled: Boolean = true
+
+  override def debug(msg: String): Unit =
+    run(log.debug(msg))
+
+  override def debug(format: String, arg: Any): Unit =
+    run(log.debug(String.format(format, arg)))
+
+  override def debug(format: String, arg1: Any, arg2: Any): Unit =
+    run(log.debug(String.format(format, arg1, arg2)))
+
+  override def debug(format: String, arguments: Any*): Unit =
+    run(log.debug(String.format(format, arguments: _*)))
+
+  override def debug(msg: String, t: Throwable): Unit =
+    run(
+      log.locally(LogAnnotation.Throwable(Some(t))) {
+        log.debug(msg)
+      }
+    )
+
+  override def isInfoEnabled: Boolean = true
+
+  override def info(msg: String): Unit =
+    run(log.info(msg))
+
+  override def info(format: String, arg: Any): Unit =
+    run(log.info(String.format(format, arg)))
+
+  override def info(format: String, arg1: Any, arg2: Any): Unit =
+    run(log.info(String.format(format, arg1, arg2)))
+
+  override def info(format: String, arguments: Any*): Unit =
+    run(log.info(String.format(format, arguments: _*)))
+
+  override def info(msg: String, t: Throwable): Unit =
+    run(
+      log.locally(LogAnnotation.Throwable(Some(t))) {
+        log.info(msg)
+      }
+    )
+
+  override def isWarnEnabled: Boolean = true
+
+  override def warn(msg: String): Unit =
+    run(log.warn(msg))
+
+  override def warn(format: String, arg: Any): Unit =
+    run(log.warn(String.format(format, arg)))
+
+  override def warn(format: String, arg1: Any, arg2: Any): Unit =
+    run(log.warn(String.format(format, arg1, arg2)))
+
+  override def warn(format: String, arguments: Any*): Unit =
+    run(log.warn(String.format(format, arguments: _*)))
+
+  override def warn(msg: String, t: Throwable): Unit =
+    run(
+      log.locally(LogAnnotation.Throwable(Some(t))) {
+        log.warn(msg)
+      }
+    )
+
+  override def isErrorEnabled: Boolean = true
+
+  override def error(msg: String): Unit =
+    run(log.error(msg))
+
+  override def error(format: String, arg: Any): Unit =
+    run(log.error(String.format(format, arg)))
+
+  override def error(format: String, arg1: Any, arg2: Any): Unit =
+    run(log.error(String.format(format, arg1, arg2)))
+
+  override def error(format: String, arguments: Any*): Unit =
+    run(log.error(String.format(format, arguments: _*)))
+
+  override def error(msg: String, t: Throwable): Unit =
+    run(
+      log.locally(LogAnnotation.Throwable(Some(t))) {
+        log.error(msg)
+      }
+    )
+}

--- a/slf4j-bridge/src/main/scala/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala/org/slf4j/impl/ZioLogger.scala
@@ -5,7 +5,7 @@ import zio.ZIO
 import zio.logging.{ log, LogAnnotation, Logging }
 
 class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringBase {
-  private val nameList = name.split('.').toList
+  private val nameList                                  = name.split('.').toList
   private def run(f: ZIO[Logging, Nothing, Unit]): Unit =
     factory.run {
       log.locally(LogAnnotation.Name(nameList))(f)
@@ -16,13 +16,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
   override def trace(msg: String): Unit =
     run(log.trace(msg))
 
-  override def trace(format: String, arg: Any): Unit =
+  override def trace(format: String, arg: AnyRef): Unit =
     run(log.trace(String.format(format, arg)))
 
-  override def trace(format: String, arg1: Any, arg2: Any): Unit =
+  override def trace(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
     run(log.trace(String.format(format, arg1, arg2)))
 
-  override def trace(format: String, arguments: Any*): Unit =
+  override def trace(format: String, arguments: AnyRef*): Unit =
     run(log.trace(String.format(format, arguments: _*)))
 
   override def trace(msg: String, t: Throwable): Unit =
@@ -37,13 +37,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
   override def debug(msg: String): Unit =
     run(log.debug(msg))
 
-  override def debug(format: String, arg: Any): Unit =
+  override def debug(format: String, arg: AnyRef): Unit =
     run(log.debug(String.format(format, arg)))
 
-  override def debug(format: String, arg1: Any, arg2: Any): Unit =
+  override def debug(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
     run(log.debug(String.format(format, arg1, arg2)))
 
-  override def debug(format: String, arguments: Any*): Unit =
+  override def debug(format: String, arguments: AnyRef*): Unit =
     run(log.debug(String.format(format, arguments: _*)))
 
   override def debug(msg: String, t: Throwable): Unit =
@@ -58,13 +58,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
   override def info(msg: String): Unit =
     run(log.info(msg))
 
-  override def info(format: String, arg: Any): Unit =
+  override def info(format: String, arg: AnyRef): Unit =
     run(log.info(String.format(format, arg)))
 
-  override def info(format: String, arg1: Any, arg2: Any): Unit =
+  override def info(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
     run(log.info(String.format(format, arg1, arg2)))
 
-  override def info(format: String, arguments: Any*): Unit =
+  override def info(format: String, arguments: AnyRef*): Unit =
     run(log.info(String.format(format, arguments: _*)))
 
   override def info(msg: String, t: Throwable): Unit =
@@ -79,13 +79,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
   override def warn(msg: String): Unit =
     run(log.warn(msg))
 
-  override def warn(format: String, arg: Any): Unit =
+  override def warn(format: String, arg: AnyRef): Unit =
     run(log.warn(String.format(format, arg)))
 
-  override def warn(format: String, arg1: Any, arg2: Any): Unit =
+  override def warn(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
     run(log.warn(String.format(format, arg1, arg2)))
 
-  override def warn(format: String, arguments: Any*): Unit =
+  override def warn(format: String, arguments: AnyRef*): Unit =
     run(log.warn(String.format(format, arguments: _*)))
 
   override def warn(msg: String, t: Throwable): Unit =
@@ -100,13 +100,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
   override def error(msg: String): Unit =
     run(log.error(msg))
 
-  override def error(format: String, arg: Any): Unit =
+  override def error(format: String, arg: AnyRef): Unit =
     run(log.error(String.format(format, arg)))
 
-  override def error(format: String, arg1: Any, arg2: Any): Unit =
+  override def error(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
     run(log.error(String.format(format, arg1, arg2)))
 
-  override def error(format: String, arguments: Any*): Unit =
+  override def error(format: String, arguments: AnyRef*): Unit =
     run(log.error(String.format(format, arguments: _*)))
 
   override def error(msg: String, t: Throwable): Unit =

--- a/slf4j-bridge/src/main/scala/org/slf4j/impl/ZioLoggerFactory.scala
+++ b/slf4j-bridge/src/main/scala/org/slf4j/impl/ZioLoggerFactory.scala
@@ -1,0 +1,30 @@
+package org.slf4j.impl
+
+import org.slf4j.{ ILoggerFactory, Logger }
+import zio.ZIO
+import zio.logging.Logging
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters._
+
+class ZioLoggerFactory extends ILoggerFactory {
+  private var runtime: zio.Runtime[Logging] = null
+  private val loggers = new ConcurrentHashMap[String, Logger]().asScala
+
+  def attachRuntime(runtime: zio.Runtime[Logging]): Unit =
+    this.runtime = runtime
+
+  private[impl] def run[A](f: ZIO[Logging, Nothing, A]): Unit =
+    if (runtime != null)
+      runtime.unsafeRun(f)
+
+  override def getLogger(name: String): Logger =
+    loggers.getOrElseUpdate(name, new ZioLogger(name, this))
+}
+
+object ZioLoggerFactory {
+  def bind(runtime: zio.Runtime[Logging]): Unit =
+    StaticLoggerBinder.getSingleton.getLoggerFactory
+      .asInstanceOf[ZioLoggerFactory]
+      .attachRuntime(runtime)
+}

--- a/slf4j-bridge/src/main/scala/org/slf4j/impl/ZioLoggerFactory.scala
+++ b/slf4j-bridge/src/main/scala/org/slf4j/impl/ZioLoggerFactory.scala
@@ -9,14 +9,16 @@ import scala.jdk.CollectionConverters._
 
 class ZioLoggerFactory extends ILoggerFactory {
   private var runtime: zio.Runtime[Logging] = null
-  private val loggers = new ConcurrentHashMap[String, Logger]().asScala
+  private val loggers                       = new ConcurrentHashMap[String, Logger]().asScala
 
   def attachRuntime(runtime: zio.Runtime[Logging]): Unit =
     this.runtime = runtime
 
   private[impl] def run[A](f: ZIO[Logging, Nothing, A]): Unit =
-    if (runtime != null)
+    if (runtime != null) {
       runtime.unsafeRun(f)
+      ()
+    }
 
   override def getLogger(name: String): Logger =
     loggers.getOrElseUpdate(name, new ZioLogger(name, this))

--- a/slf4j-bridge/src/main/scala/zio/logging/slf4j/bridge/package.scala
+++ b/slf4j-bridge/src/main/scala/zio/logging/slf4j/bridge/package.scala
@@ -1,0 +1,17 @@
+package zio.logging.slf4j
+
+import org.slf4j.impl.ZioLoggerFactory
+import zio.{ ZIO, ZLayer }
+import zio.logging.Logging
+
+package object bridge {
+  def bindSlf4jBridge[R <: Logging]: ZLayer[R, Nothing, R] =
+    ZIO
+      .runtime[R]
+      .flatMap { runtime =>
+        ZIO.effectTotal {
+          ZioLoggerFactory.bind(runtime)
+          runtime.environment
+        }
+      }.toLayerMany
+}

--- a/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
+++ b/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
@@ -1,0 +1,53 @@
+package zio.logging.slf4j.bridge
+
+import zio.ZIO
+import zio.logging.LoggerSpec.TestLogger
+import zio.logging.{ LogAnnotation, LogContext, LogLevel }
+import zio.test.Assertion._
+import zio.test._
+
+object Slf4jBridgeSpec extends DefaultRunnableSpec {
+  override def spec =
+    suite("Slf4jBridge")(
+      testM("logs through slf4j") {
+        for {
+          logger <- ZIO.effect(org.slf4j.LoggerFactory.getLogger("test.logger"))
+          _      <- ZIO.effect(logger.debug("test debug message"))
+          _      <- ZIO.effect(logger.warn("hello %s", "world"))
+          testFailure = new RuntimeException("test error")
+          _      <- ZIO.effect(logger.error("error", testFailure))
+          lines  <- TestLogger.lines
+        } yield assert(lines)(
+          equalTo(
+            /*
+             Vector(
+             (LogContext(Map(LogAnnotation(name) -> List(test-logger), LogAnnotation(level) -> Debug)),test debug message),
+             (LogContext(Map(LogAnnotation(name) -> List(test-logger), LogAnnotation(level) -> Warn)),hello world),
+             (LogContext(Map(LogAnnotation(name) -> List(test-logger), LogAnnotation(throwable) -> Some(java.lang.RuntimeException: test error), LogAnnotation(level) -> Error)),error))
+             */
+            Vector(
+              (
+                LogContext.empty
+                  .annotate(LogAnnotation.Level, LogLevel.Debug)
+                  .annotate(LogAnnotation.Name, List("test", "logger")),
+                "test debug message"
+              ),
+              (
+                LogContext.empty
+                  .annotate(LogAnnotation.Level, LogLevel.Warn)
+                  .annotate(LogAnnotation.Name, List("test", "logger")),
+                "hello world"
+              ),
+              (
+                LogContext.empty
+                  .annotate(LogAnnotation.Level, LogLevel.Error)
+                  .annotate(LogAnnotation.Name, List("test", "logger"))
+                  .annotate(LogAnnotation.Throwable, Some(testFailure)),
+                "error"
+              )
+            )
+          )
+        )
+      }
+    ).provideCustomLayer(TestLogger.make >>> bindSlf4jBridge)
+}


### PR DESCRIPTION
This PR adds a new module called `zio-logging-slf4j-bridge`, which is the "opposite" of the existing SLF4j support, registering `zio-logging` as an SLF4j provider. 
With this third party libraries logging through SLF4j can log through zio-logging without the need to a third party slf4j implementation.

This is good for reducing dependencies and simplify the whole logging stack of services.
For example we are using this for mixing in sttp and Netty logs to the zio-logging log stream of a service.

Easy filtering configuration makes this much more usable, a proposed solution for that is coming in another PR.