### PR TITLE
Capturing a Cause->Throwable converter in the log annotation

### DIFF
--- a/core/src/main/scala/zio/logging/CapturedCause.scala
+++ b/core/src/main/scala/zio/logging/CapturedCause.scala
@@ -1,0 +1,28 @@
+package zio.logging
+
+import zio.Cause
+
+sealed trait CapturedCause {
+  val cause: Cause[Any]
+  def toThrowable: Throwable
+}
+
+object CapturedCause {
+  def apply[E: CauseToThrowable](c: Cause[E]): CapturedCause =
+    new CapturedCause {
+      override val cause: Cause[Any]      = c
+      override def toThrowable: Throwable =
+        implicitly[CauseToThrowable[E]].toThrowable(c)
+    }
+
+  trait CauseToThrowable[-E] {
+    def toThrowable(cause: Cause[E]): Throwable
+  }
+
+  implicit def throwableCause[E <: Throwable]: CauseToThrowable[E] = (cause: Cause[E]) => cause.squash
+  implicit val nothingCause: CauseToThrowable[Nothing]             = (_: Cause[Nothing]) => new RuntimeException("Nothing")
+
+  object causeToRuntimeException {
+    implicit def toThrowable[E]: CauseToThrowable[E] = (cause: Cause[E]) => new RuntimeException(cause.prettyPrint)
+  }
+}

--- a/core/src/main/scala/zio/logging/LogAnnotation.scala
+++ b/core/src/main/scala/zio/logging/LogAnnotation.scala
@@ -1,9 +1,6 @@
 package zio.logging
 
 import java.time.OffsetDateTime
-
-import zio.Cause
-
 import scala.reflect.ClassTag
 
 /**
@@ -70,11 +67,11 @@ object LogAnnotation {
    * The `Cause` annotation keeps track of a Cause.
    */
   val Cause =
-    LogAnnotation[Option[Cause[Any]]](
+    LogAnnotation[Option[CapturedCause]](
       name = "cause",
       initialValue = None,
       combine = (_, t) => t,
-      _.map(_.prettyPrint).getOrElse("")
+      _.map(_.cause.prettyPrint).getOrElse("")
     )
 
   /**

--- a/core/src/main/scala/zio/logging/LogFormat.scala
+++ b/core/src/main/scala/zio/logging/LogFormat.scala
@@ -33,9 +33,9 @@ object LogFormat {
       val loggerName = context(LogAnnotation.Name)
       val maybeError = context
         .get(LogAnnotation.Throwable)
-        .map(Cause.fail)
+        .map(throwable => CapturedCause(Cause.fail(throwable)))
         .orElse(context.get(LogAnnotation.Cause))
-        .map(cause => NL + cause.prettyPrint)
+        .map(cause => NL + cause.cause.prettyPrint)
         .getOrElse("")
       date + " " + level + " " + loggerName + " " + format0(context, line) + " " + maybeError
     }
@@ -76,9 +76,9 @@ object LogFormat {
       val loggerName = context(LogAnnotation.Name)
       val maybeError = context
         .get(LogAnnotation.Throwable)
-        .map(Cause.fail)
+        .map(throwable => CapturedCause(Cause.fail(throwable)))
         .orElse(context.get(LogAnnotation.Cause))
-        .map(_.prettyPrint)
+        .map(_.cause.prettyPrint)
       format(lineFormat(context, line), date, level, loggerName, maybeError)
     }
   }

--- a/core/src/main/scala/zio/logging/Logging.scala
+++ b/core/src/main/scala/zio/logging/Logging.scala
@@ -2,10 +2,10 @@ package zio.logging
 
 import java.nio.charset.{ Charset, StandardCharsets }
 import java.nio.file.Path
-
 import zio._
 import zio.clock._
 import zio.console.Console
+import zio.logging.CapturedCause.CauseToThrowable
 import zio.logging.Logger.LoggerWithFormat
 
 object Logging {
@@ -48,7 +48,7 @@ object Logging {
   def error(line: => String): ZIO[Logging, Nothing, Unit] =
     ZIO.accessM[Logging](_.get.error(line))
 
-  def error(line: => String, cause: Cause[Any]): ZIO[Logging, Nothing, Unit] =
+  def error[E: CauseToThrowable](line: => String, cause: Cause[E]): ZIO[Logging, Nothing, Unit] =
     ZIO.accessM[Logging](_.get.error(line, cause))
 
   def file(

--- a/core/src/main/scala/zio/logging/log.scala
+++ b/core/src/main/scala/zio/logging/log.scala
@@ -1,5 +1,6 @@
 package zio.logging
 
+import zio.logging.CapturedCause.CauseToThrowable
 import zio.{ Cause, URIO, ZIO }
 
 object log {
@@ -19,7 +20,7 @@ object log {
   def error(line: => String): ZIO[Logging, Nothing, Unit] =
     Logging.error(line)
 
-  def error(line: => String, cause: Cause[Any]): ZIO[Logging, Nothing, Unit] =
+  def error[E: CauseToThrowable](line: => String, cause: Cause[E]): ZIO[Logging, Nothing, Unit] =
     Logging.error(line, cause)
 
   def info(line: => String): ZIO[Logging, Nothing, Unit] =


### PR DESCRIPTION
This is a bit bigger change as it breaks the API but I believe something like this would make the library much easier to use with custom (non `Throwable`) error types. 

I bumped into this when tried to log errors through the SLF4j logger in a way they appear errors (exceptions) for the logger while still using more well typed errors on the ZIO level. The two primary reason why this is a good idea, I think is:
- The current SLF4j logger does nothing with the `Cause` annotation. This is what I first ran into, logging errors with `error(msg, cause)` and not seeing the cause in any way in the `zio-logging -> slf4j -> log4j2` chain's output. Without my change in the `slf4j` module the only thing you can do is `prettyPrint` the cause to a string, but then there is no straightforward way to pass it down to the underlying logger (except appending to the given message but that's weird)
- With some appenders it is more important to pass error causes in the "standard" way, as throwables attached to the log entries. For an example consider the Sentry appender.

So the change in this PR introduces an implicit conversion from `E` to `Throwable` for logging purposes, with default implementation for `E <: Throwable` and `Nothing`.