### PR TITLE
Upgrade to ZIO 2.0.0-RC3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ inThisBuild(
   )
 )
 
-val ZioVersion           = "2.0.0-RC2"
+val ZioVersion           = "2.0.0-RC3"
 val scalaJavaTimeVersion = "2.3.0"
 val slf4jVersion         = "1.7.35"
 

--- a/core/jvm/src/test/scala/zio/logging/LogFormatSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/LogFormatSpec.scala
@@ -1,7 +1,7 @@
 package zio.logging
 
 import zio.test._
-import zio.{ FiberId, LogLevel, ZTraceElement }
+import zio.{ Cause, FiberId, LogLevel, ZTraceElement }
 
 import LogFormat.{ level, line, _ }
 
@@ -16,9 +16,9 @@ object LogFormatSpec extends DefaultRunnableSpec {
             FiberId.None,
             LogLevel.Info,
             () => line,
+            Cause.empty,
             Map.empty,
             Nil,
-            ZTraceElement.empty,
             Map.empty
           )
         assertTrue(result == line)
@@ -33,9 +33,9 @@ object LogFormatSpec extends DefaultRunnableSpec {
             FiberId.None,
             level,
             () => "",
+            Cause.empty,
             Map.empty,
             Nil,
-            ZTraceElement.empty,
             Map.empty
           )
         assertTrue(result == level.label)
@@ -50,9 +50,9 @@ object LogFormatSpec extends DefaultRunnableSpec {
             FiberId.None,
             level,
             () => "",
+            Cause.empty,
             Map.empty,
             Nil,
-            ZTraceElement.empty,
             Map.empty
           )
         assertTrue(result == level.syslog.toString)
@@ -63,12 +63,12 @@ object LogFormatSpec extends DefaultRunnableSpec {
       check(Gen.int, Gen.int) { (seq, time) =>
         val result = format.toLogger(
           ZTraceElement.empty,
-          FiberId(seq, time),
+          FiberId(seq, time, ZTraceElement.empty),
           LogLevel.Info,
           () => "",
+          Cause.empty,
           Map.empty,
           Nil,
-          ZTraceElement.empty,
           Map.empty
         )
         assertTrue(result == s"zio-fiber-$seq")
@@ -82,9 +82,9 @@ object LogFormatSpec extends DefaultRunnableSpec {
           FiberId.None,
           LogLevel.Info,
           () => "",
+          Cause.empty,
           Map.empty,
           Nil,
-          ZTraceElement.empty,
           Map("test" -> annotationValue)
         )
         assertTrue(result == s"test=$annotationValue")
@@ -98,9 +98,9 @@ object LogFormatSpec extends DefaultRunnableSpec {
           FiberId.None,
           LogLevel.Info,
           () => "",
+          Cause.empty,
           Map(logContext -> LogContext.empty.annotate(LogAnnotation.UserId, annotationValue)),
           Nil,
-          ZTraceElement.empty,
           Map.empty
         )
         assertTrue(result == s"user_id=$annotationValue")
@@ -113,9 +113,9 @@ object LogFormatSpec extends DefaultRunnableSpec {
         FiberId.None,
         LogLevel.Info,
         () => "",
+        Cause.empty,
         Map.empty,
         Nil,
-        ZTraceElement.empty,
         Map.empty
       )
       assertTrue(result == "")
@@ -128,9 +128,9 @@ object LogFormatSpec extends DefaultRunnableSpec {
           FiberId.None,
           LogLevel.Info,
           () => "",
+          Cause.empty,
           Map.empty,
           Nil,
-          ZTraceElement.empty,
           Map.empty
         )
       assertTrue(result == "")
@@ -144,9 +144,9 @@ object LogFormatSpec extends DefaultRunnableSpec {
             FiberId.None,
             LogLevel.Info,
             () => line,
+            Cause.empty,
             Map.empty,
             Nil,
-            ZTraceElement.empty,
             Map.empty
           )
         assertTrue(result == "a" + line + "c")
@@ -161,9 +161,9 @@ object LogFormatSpec extends DefaultRunnableSpec {
             FiberId.None,
             LogLevel.Info,
             () => line,
+            Cause.empty,
             Map.empty,
             Nil,
-            ZTraceElement.empty,
             Map.empty
           )
         assertTrue(result == line + " c")
@@ -178,9 +178,9 @@ object LogFormatSpec extends DefaultRunnableSpec {
             FiberId.None,
             LogLevel.Info,
             () => line,
+            Cause.empty,
             Map.empty,
             Nil,
-            ZTraceElement.empty,
             Map.empty
           )
         assertTrue(result == LogColor.RED.ansi + line + LogColor.RESET.ansi)
@@ -194,9 +194,9 @@ object LogFormatSpec extends DefaultRunnableSpec {
           FiberId.None,
           LogLevel.Info,
           () => line,
+          Cause.empty,
           Map.empty,
           Nil,
-          ZTraceElement.empty,
           Map.empty
         )
         assertTrue(result.size == 10)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.typesafe"                      % "sbt-mima-plugin"            
 addSbtPlugin("de.heikoseeberger"                 % "sbt-header"                    % "5.6.0")
 addSbtPlugin("org.portable-scala"                % "sbt-scala-native-crossproject" % "1.1.0")
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject"      % "1.1.0")
-addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "1.7.1")
+addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "1.9.0")
 addSbtPlugin("org.scala-native"                  % "sbt-scala-native"              % "0.4.1")
 addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                      % "2.2.24")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.4.3")

--- a/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
@@ -3,7 +3,7 @@ package zio.logging.backend
 import com.github.ghik.silencer.silent
 import org.slf4j.{ LoggerFactory, MDC }
 import zio.logging.LogFormat
-import zio.{ FiberId, LogLevel, LogSpan, RuntimeConfigAspect, ZFiberRef, ZLogger, ZTraceElement }
+import zio.{ Cause, FiberId, LogLevel, LogSpan, RuntimeConfigAspect, ZFiberRef, ZLogger, ZTraceElement }
 
 import scala.collection.JavaConverters._
 
@@ -41,12 +41,12 @@ object SLF4J {
         fiberId: FiberId,
         logLevel: LogLevel,
         message: () => String,
+        cause: Cause[Any],
         context: Map[ZFiberRef.Runtime[_], AnyRef],
         spans: List[LogSpan],
-        location: ZTraceElement,
         annotations: Map[String, String]
       ): Unit =
-        formatLogger(trace, fiberId, logLevel, message, context, spans, location, annotations).foreach { message =>
+        formatLogger(trace, fiberId, logLevel, message, cause, context, spans, annotations).foreach { message =>
           val slf4jLogger = LoggerFactory.getLogger(rootLoggerName(trace))
 
           val previous =


### PR DESCRIPTION
Hi!
I was playing around with `zio-logging` and its `slf4j ` support over the weekenad  and noticed that the latest changes from `ZIO 2.0.0-RC3` have not been accounted for in `zio-logging` yet.
This commit upgrade the ZIO version to `ZIO 2.0.0-RC3` with the necessary code adjustments.

Using the commit above this worked nicely for me:
```
package zio2.testapp

import zio.{LogLevel, RuntimeConfigAspect, ZEnv, ZIO, ZLogger}

object TestApp extends zio.ZIOAppDefault {

  def slf4jLoggerAspect: RuntimeConfigAspect = {
    zio.logging.backend.SLF4J.slf4j(LogLevel.Info)
  }

  override def run: ZIO[ZEnv, Any, Any] = {
    for {
      config <- ZIO.runtimeConfig.map(c => c.copy(logger = ZLogger.none) @@ slf4jLoggerAspect) // reset logger and add slf4j logger
      _      <- ZIO.setRuntimeConfig(config)
      r      <- ZIO.log("ZIO logging test!!")
    } yield {
      r
    }
  }
}
```

Hope this is useful!