### PR TITLE
Implement Remove Default Loggers

### DIFF
--- a/core/shared/src/main/scala/zio/logging/package.scala
+++ b/core/shared/src/main/scala/zio/logging/package.scala
@@ -100,6 +100,11 @@ package object logging {
       } yield ()
     }
 
+  val removeDefaultLoggers: ZLayer[Any, Nothing, Unit] = {
+    implicit val trace = Trace.empty
+    ZLayer.scoped(FiberRef.currentLoggers.locallyScopedWith(_ -- Runtime.defaultLoggers))
+  }
+
   private def makeStringLogger(
     destination: Path,
     format: LogFormat,


### PR DESCRIPTION
This functionality already exists on the latest version of `series/2.x` but we can implement it here for now and do another release so that people who had an issue with this can get started doing logging with `RC6`.