### PR TITLE
LogFormat for annotations and spans

### DIFF
--- a/core/shared/src/main/scala/zio/logging/LogFormat.scala
+++ b/core/shared/src/main/scala/zio/logging/LogFormat.scala
@@ -205,20 +205,23 @@ object LogFormat {
       List[LogSpan],
       Map[String, String]
     ) => Any
-  ): LogFormat = (builder: LogAppender) =>
-    (
-      trace: Trace,
-      fiberId: FiberId,
-      logLevel: LogLevel,
-      message: () => String,
-      cause: Cause[Any],
-      context: FiberRefs,
-      spans: List[LogSpan],
-      annotations: Map[String, String]
-    ) => {
-      format(builder, trace, fiberId, logLevel, message, cause, context, spans, annotations)
-      ()
+  ): LogFormat = { (builder: LogAppender) =>
+    new ZLogger[String, Unit] {
+      override def apply(
+        trace: Trace,
+        fiberId: FiberId,
+        logLevel: LogLevel,
+        message: () => String,
+        cause: Cause[Any],
+        context: FiberRefs,
+        spans: List[LogSpan],
+        annotations: Map[String, String]
+      ): Unit = {
+        format(builder, trace, fiberId, logLevel, message, cause, context, spans, annotations)
+        ()
+      }
     }
+  }
 
   def annotation(name: String): LogFormat =
     LogFormat.make { (builder, _, _, _, _, _, _, _, annotations) =>

--- a/core/shared/src/main/scala/zio/logging/LogFormat.scala
+++ b/core/shared/src/main/scala/zio/logging/LogFormat.scala
@@ -240,6 +240,16 @@ object LogFormat {
         }
     }
 
+  /**
+   * Returns a new log format that appends all annotations to the log output.
+   */
+  def annotations: LogFormat =
+    LogFormat.make { (builder, _, _, _, _, _, _, _, annotations) =>
+      annotations.foreach { case (key, value) =>
+        builder.appendKeyValue(key, value)
+      }
+    }
+
   def bracketed(inner: LogFormat): LogFormat =
     bracketStart + inner + bracketEnd
 

--- a/core/shared/src/main/scala/zio/logging/LogFormat.scala
+++ b/core/shared/src/main/scala/zio/logging/LogFormat.scala
@@ -309,6 +309,28 @@ object LogFormat {
 
   def quoted(inner: LogFormat): LogFormat = quote + inner + quote
 
+  /**
+   * Returns a new log format that appends the specified span to the log output.
+   */
+  def span(name: String): LogFormat =
+    LogFormat.make { (builder, _, _, _, _, _, _, spans, _) =>
+      spans.find(_.label == name).foreach { span =>
+        val duration = (java.lang.System.currentTimeMillis() - span.startTime).toString
+        builder.appendKeyValue(name, duration)
+      }
+    }
+
+  /**
+   * Returns a new log format that appends all spans to the log output.
+   */
+  def spans: LogFormat =
+    LogFormat.make { (builder, _, _, _, _, _, _, spans, _) =>
+      spans.foreach { span =>
+        val duration = (java.lang.System.currentTimeMillis() - span.startTime).toString
+        builder.appendKeyValue(span.label, duration + "ms")
+      }
+    }
+
   def text(value: => String): LogFormat =
     LogFormat.make { (builder, _, _, _, _, _, _, _, _) =>
       builder.appendText(value)


### PR DESCRIPTION
This PR adds `annotations` which include all annotations in the `LogFormat`.
Also adds `span` and `spans` to include spans in the `LogFormat`.