### PR TITLE
slf4j bridge message format

### DIFF
--- a/slf4j-bridge/src/main/scala-2/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala-2/org/slf4j/impl/ZioLogger.scala
@@ -21,7 +21,7 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logTrace(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def trace(format: String, arguments: AnyRef*): Unit =
-    run(ZIO.logTrace(MessageFormatter.format(format, Array(arguments)).getMessage))
+    run(ZIO.logTrace(MessageFormatter.arrayFormat(format, arguments.toArray).getMessage))
 
   override def trace(msg: String, t: Throwable): Unit =
     run(
@@ -40,7 +40,7 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logDebug(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def debug(format: String, arguments: AnyRef*): Unit =
-    run(ZIO.logDebug(MessageFormatter.format(format, Array(arguments)).getMessage))
+    run(ZIO.logDebug(MessageFormatter.arrayFormat(format, arguments.toArray).getMessage))
 
   override def debug(msg: String, t: Throwable): Unit =
     run(
@@ -59,7 +59,7 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logInfo(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def info(format: String, arguments: AnyRef*): Unit =
-    run(ZIO.logInfo(MessageFormatter.format(format, Array(arguments)).getMessage))
+    run(ZIO.logInfo(MessageFormatter.arrayFormat(format, arguments.toArray).getMessage))
 
   override def info(msg: String, t: Throwable): Unit =
     run(
@@ -78,7 +78,7 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logWarning(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def warn(format: String, arguments: AnyRef*): Unit =
-    run(ZIO.logWarning(MessageFormatter.format(format, Array(arguments)).getMessage))
+    run(ZIO.logWarning(MessageFormatter.arrayFormat(format, arguments.toArray).getMessage))
 
   override def warn(msg: String, t: Throwable): Unit =
     run(
@@ -97,7 +97,7 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logError(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def error(format: String, arguments: AnyRef*): Unit =
-    run(ZIO.logError(MessageFormatter.format(format, Array(arguments)).getMessage))
+    run(ZIO.logError(MessageFormatter.arrayFormat(format, arguments.toArray).getMessage))
 
   override def error(msg: String, t: Throwable): Unit =
     run(

--- a/slf4j-bridge/src/main/scala-2/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala-2/org/slf4j/impl/ZioLogger.scala
@@ -1,6 +1,6 @@
 package org.slf4j.impl
 
-import org.slf4j.helpers.MarkerIgnoringBase
+import org.slf4j.helpers.{ MarkerIgnoringBase, MessageFormatter }
 import zio.{ Cause, ZIO }
 
 class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringBase {
@@ -15,13 +15,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logTrace(msg))
 
   override def trace(format: String, arg: AnyRef): Unit =
-    run(ZIO.logTrace(String.format(format, arg)))
+    run(ZIO.logTrace(MessageFormatter.format(format, arg).getMessage))
 
   override def trace(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
-    run(ZIO.logTrace(String.format(format, arg1, arg2)))
+    run(ZIO.logTrace(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def trace(format: String, arguments: AnyRef*): Unit =
-    run(ZIO.logTrace(String.format(format, arguments: _*)))
+    run(ZIO.logTrace(MessageFormatter.format(format, Array(arguments)).getMessage))
 
   override def trace(msg: String, t: Throwable): Unit =
     run(
@@ -34,13 +34,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logDebug(msg))
 
   override def debug(format: String, arg: AnyRef): Unit =
-    run(ZIO.logDebug(String.format(format, arg)))
+    run(ZIO.logDebug(MessageFormatter.format(format, arg).getMessage))
 
   override def debug(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
-    run(ZIO.logDebug(String.format(format, arg1, arg2)))
+    run(ZIO.logDebug(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def debug(format: String, arguments: AnyRef*): Unit =
-    run(ZIO.logDebug(String.format(format, arguments: _*)))
+    run(ZIO.logDebug(MessageFormatter.format(format, Array(arguments)).getMessage))
 
   override def debug(msg: String, t: Throwable): Unit =
     run(
@@ -53,13 +53,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logInfo(msg))
 
   override def info(format: String, arg: AnyRef): Unit =
-    run(ZIO.logInfo(String.format(format, arg)))
+    run(ZIO.logInfo(MessageFormatter.format(format, arg).getMessage))
 
   override def info(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
-    run(ZIO.logInfo(String.format(format, arg1, arg2)))
+    run(ZIO.logInfo(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def info(format: String, arguments: AnyRef*): Unit =
-    run(ZIO.logInfo(String.format(format, arguments: _*)))
+    run(ZIO.logInfo(MessageFormatter.format(format, Array(arguments)).getMessage))
 
   override def info(msg: String, t: Throwable): Unit =
     run(
@@ -72,13 +72,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logWarning(msg))
 
   override def warn(format: String, arg: AnyRef): Unit =
-    run(ZIO.logWarning(String.format(format, arg)))
+    run(ZIO.logWarning(MessageFormatter.format(format, arg).getMessage))
 
   override def warn(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
-    run(ZIO.logWarning(String.format(format, arg1, arg2)))
+    run(ZIO.logWarning(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def warn(format: String, arguments: AnyRef*): Unit =
-    run(ZIO.logWarning(String.format(format, arguments: _*)))
+    run(ZIO.logWarning(MessageFormatter.format(format, Array(arguments)).getMessage))
 
   override def warn(msg: String, t: Throwable): Unit =
     run(
@@ -91,13 +91,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logError(msg))
 
   override def error(format: String, arg: AnyRef): Unit =
-    run(ZIO.logError(String.format(format, arg)))
+    run(ZIO.logError(MessageFormatter.format(format, arg).getMessage))
 
   override def error(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
-    run(ZIO.logError(String.format(format, arg1, arg2)))
+    run(ZIO.logError(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def error(format: String, arguments: AnyRef*): Unit =
-    run(ZIO.logError(String.format(format, arguments: _*)))
+    run(ZIO.logError(MessageFormatter.format(format, Array(arguments)).getMessage))
 
   override def error(msg: String, t: Throwable): Unit =
     run(

--- a/slf4j-bridge/src/main/scala-3/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala-3/org/slf4j/impl/ZioLogger.scala
@@ -1,6 +1,6 @@
 package org.slf4j.impl
 
-import org.slf4j.helpers.MarkerIgnoringBase
+import org.slf4j.helpers.{ MarkerIgnoringBase, MessageFormatter }
 import zio.{ Cause, ZIO }
 
 class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringBase {
@@ -15,13 +15,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logTrace(msg))
 
   override def trace(format: String, arg: AnyRef): Unit =
-    run(ZIO.logTrace(String.format(format, arg)))
+    run(ZIO.logTrace(MessageFormatter.format(format, arg).getMessage))
 
   override def trace(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
-    run(ZIO.logTrace(String.format(format, arg1, arg2)))
+    run(ZIO.logTrace(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def trace(format: String, arguments: Array[? <: Object]): Unit =
-    run(ZIO.logTrace(String.format(format, arguments: _*)))
+    run(ZIO.logTrace(MessageFormatter.format(format, arguments).getMessage))
 
   override def trace(msg: String, t: Throwable): Unit =
     run(
@@ -34,13 +34,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logDebug(msg))
 
   override def debug(format: String, arg: AnyRef): Unit =
-    run(ZIO.logDebug(String.format(format, arg)))
+    run(ZIO.logDebug(MessageFormatter.format(format, arg).getMessage))
 
   override def debug(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
-    run(ZIO.logDebug(String.format(format, arg1, arg2)))
+    run(ZIO.logDebug(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def debug(format: String, arguments: Array[? <: Object]): Unit =
-    run(ZIO.logDebug(String.format(format, arguments: _*)))
+    run(ZIO.logDebug(MessageFormatter.format(format, arguments).getMessage))
 
   override def debug(msg: String, t: Throwable): Unit =
     run(
@@ -53,13 +53,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logInfo(msg))
 
   override def info(format: String, arg: AnyRef): Unit =
-    run(ZIO.logInfo(String.format(format, arg)))
+    run(ZIO.logInfo(MessageFormatter.format(format, arg).getMessage))
 
   override def info(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
-    run(ZIO.logInfo(String.format(format, arg1, arg2)))
+    run(ZIO.logInfo(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def info(format: String, arguments: Array[? <: Object]): Unit =
-    run(ZIO.logInfo(String.format(format, arguments: _*)))
+    run(ZIO.logInfo(MessageFormatter.format(format, arguments).getMessage))
 
   override def info(msg: String, t: Throwable): Unit =
     run(
@@ -72,13 +72,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logWarning(msg))
 
   override def warn(format: String, arg: AnyRef): Unit =
-    run(ZIO.logWarning(String.format(format, arg)))
+    run(ZIO.logWarning(MessageFormatter.format(format, arg).getMessage))
 
   override def warn(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
-    run(ZIO.logWarning(String.format(format, arg1, arg2)))
+    run(ZIO.logWarning(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def warn(format: String, arguments: Array[? <: Object]): Unit =
-    run(ZIO.logWarning(String.format(format, arguments: _*)))
+    run(ZIO.logWarning(MessageFormatter.format(format, arguments).getMessage))
 
   override def warn(msg: String, t: Throwable): Unit =
     run(
@@ -91,13 +91,13 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logError(msg))
 
   override def error(format: String, arg: AnyRef): Unit =
-    run(ZIO.logError(String.format(format, arg)))
+    run(ZIO.logError(MessageFormatter.format(format, arg).getMessage))
 
   override def error(format: String, arg1: AnyRef, arg2: AnyRef): Unit =
-    run(ZIO.logError(String.format(format, arg1, arg2)))
+    run(ZIO.logError(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def error(format: String, arguments: Array[? <: Object]): Unit =
-    run(ZIO.logError(String.format(format, arguments: _*)))
+    run(ZIO.logError(MessageFormatter.format(format, arguments).getMessage))
 
   override def error(msg: String, t: Throwable): Unit =
     run(

--- a/slf4j-bridge/src/main/scala-3/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala-3/org/slf4j/impl/ZioLogger.scala
@@ -21,7 +21,7 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logTrace(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def trace(format: String, arguments: Array[? <: Object]): Unit =
-    run(ZIO.logTrace(MessageFormatter.format(format, arguments).getMessage))
+    run(ZIO.logTrace(MessageFormatter.arrayFormat(format, arguments.asInstanceOf[Array[Object]]).getMessage))
 
   override def trace(msg: String, t: Throwable): Unit =
     run(
@@ -40,7 +40,7 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logDebug(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def debug(format: String, arguments: Array[? <: Object]): Unit =
-    run(ZIO.logDebug(MessageFormatter.format(format, arguments).getMessage))
+    run(ZIO.logDebug(MessageFormatter.arrayFormat(format, arguments.asInstanceOf[Array[Object]]).getMessage))
 
   override def debug(msg: String, t: Throwable): Unit =
     run(
@@ -59,7 +59,7 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logInfo(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def info(format: String, arguments: Array[? <: Object]): Unit =
-    run(ZIO.logInfo(MessageFormatter.format(format, arguments).getMessage))
+    run(ZIO.logInfo(MessageFormatter.arrayFormat(format, arguments.asInstanceOf[Array[Object]]).getMessage))
 
   override def info(msg: String, t: Throwable): Unit =
     run(
@@ -78,7 +78,7 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logWarning(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def warn(format: String, arguments: Array[? <: Object]): Unit =
-    run(ZIO.logWarning(MessageFormatter.format(format, arguments).getMessage))
+    run(ZIO.logWarning(MessageFormatter.arrayFormat(format, arguments.asInstanceOf[Array[Object]]).getMessage))
 
   override def warn(msg: String, t: Throwable): Unit =
     run(
@@ -97,7 +97,7 @@ class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringB
     run(ZIO.logError(MessageFormatter.format(format, arg1, arg2).getMessage))
 
   override def error(format: String, arguments: Array[? <: Object]): Unit =
-    run(ZIO.logError(MessageFormatter.format(format, arguments).getMessage))
+    run(ZIO.logError(MessageFormatter.arrayFormat(format, arguments.asInstanceOf[Array[Object]]).getMessage))
 
   override def error(msg: String, t: Throwable): Unit =
     run(

--- a/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
+++ b/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
@@ -21,7 +21,7 @@ object Slf4jBridgeSpec extends ZIOSpecDefault {
           _      <- (for {
                       logger <- ZIO.attempt(org.slf4j.LoggerFactory.getLogger("test.logger"))
                       _      <- ZIO.attempt(logger.debug("test debug message"))
-                      _      <- ZIO.attempt(logger.warn("hello %s", "world"))
+                      _      <- ZIO.attempt(logger.warn("hello {}", "world"))
                       _      <- ZIO.attempt(logger.warn("warn cause", testFailure))
                       _      <- ZIO.attempt(logger.error("error", testFailure))
                     } yield ()).exit

--- a/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
+++ b/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
@@ -22,6 +22,7 @@ object Slf4jBridgeSpec extends ZIOSpecDefault {
                       logger <- ZIO.attempt(org.slf4j.LoggerFactory.getLogger("test.logger"))
                       _      <- ZIO.attempt(logger.debug("test debug message"))
                       _      <- ZIO.attempt(logger.warn("hello {}", "world"))
+                      _      <- ZIO.attempt(logger.warn("{}..{}..{} ... go!", "3", "2", "1"))
                       _      <- ZIO.attempt(logger.warn("warn cause", testFailure))
                       _      <- ZIO.attempt(logger.error("error", testFailure))
                     } yield ()).exit
@@ -49,6 +50,13 @@ object Slf4jBridgeSpec extends ZIOSpecDefault {
               LogLevel.Warning,
               Map.empty,
               "hello world",
+              Cause.empty
+            ),
+            LogEntry(
+              List("test.logger"),
+              LogLevel.Warning,
+              Map.empty,
+              "3..2..1 ... go!",
               Cause.empty
             ),
             LogEntry(


### PR DESCRIPTION
slf4j bridge message format fix: #482

slf4j using `{}` as placeholder
https://www.tutorialspoint.com/slf4j/slf4j_parameterized_logging.htm