### PR TITLE
ci publish fixes - jdk11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Scala and Java
         uses: olafurpg/setup-scala@v13
+        with:
+          java-version: adopt@1.11
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
       - name: Release artifacts

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: olafurpg/setup-scala@v13
+        with:
+          java-version: adopt@1.11
       - run: sbt docs/docusaurusPublishGhpages
         env:
           GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}


### PR DESCRIPTION
used jdk11, because java system logger (jpl) was introduced in jdk9