### PR TITLE
Give proper logger name to SLF4J bridge

### DIFF
--- a/slf4j-bridge/src/main/java/org/slf4j/helpers/ZioLoggerBase.java
+++ b/slf4j-bridge/src/main/java/org/slf4j/helpers/ZioLoggerBase.java
@@ -1,0 +1,8 @@
+package org.slf4j.helpers;
+
+public abstract class ZioLoggerBase extends MarkerIgnoringBase {
+
+    public ZioLoggerBase(String name) {
+        this.name = name;
+    }
+}

--- a/slf4j-bridge/src/main/scala-2/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala-2/org/slf4j/impl/ZioLogger.scala
@@ -4,6 +4,9 @@ import org.slf4j.helpers.{ MarkerIgnoringBase, MessageFormatter }
 import zio.{ Cause, ZIO }
 
 class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringBase {
+
+  override def getName: String = name
+
   private def run(f: ZIO[Any, Nothing, Unit]): Unit =
     factory.run {
       ZIO.logSpan(name)(f)

--- a/slf4j-bridge/src/main/scala-2/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala-2/org/slf4j/impl/ZioLogger.scala
@@ -1,11 +1,9 @@
 package org.slf4j.impl
 
-import org.slf4j.helpers.{ MarkerIgnoringBase, MessageFormatter }
+import org.slf4j.helpers.{ MessageFormatter, ZioLoggerBase }
 import zio.{ Cause, ZIO }
 
-class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringBase {
-
-  override def getName: String = name
+class ZioLogger(name: String, factory: ZioLoggerFactory) extends ZioLoggerBase(name) {
 
   private def run(f: ZIO[Any, Nothing, Unit]): Unit =
     factory.run {

--- a/slf4j-bridge/src/main/scala-3/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala-3/org/slf4j/impl/ZioLogger.scala
@@ -4,6 +4,9 @@ import org.slf4j.helpers.{ MarkerIgnoringBase, MessageFormatter }
 import zio.{ Cause, ZIO }
 
 class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringBase {
+
+  override def getName: String = name
+
   private def run(f: ZIO[Any, Nothing, Unit]): Unit =
     factory.run {
       ZIO.logSpan(name)(f)

--- a/slf4j-bridge/src/main/scala-3/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala-3/org/slf4j/impl/ZioLogger.scala
@@ -1,11 +1,9 @@
 package org.slf4j.impl
 
-import org.slf4j.helpers.{ MarkerIgnoringBase, MessageFormatter }
+import org.slf4j.helpers.{ MessageFormatter, ZioLoggerBase }
 import zio.{ Cause, ZIO }
 
-class ZioLogger(name: String, factory: ZioLoggerFactory) extends MarkerIgnoringBase {
-
-  override def getName: String = name
+class ZioLogger(name: String, factory: ZioLoggerFactory) extends ZioLoggerBase(name) {
 
   private def run(f: ZIO[Any, Nothing, Unit]): Unit =
     factory.run {

--- a/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
+++ b/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
@@ -13,7 +13,7 @@ object Slf4jBridgeSpec extends ZIOSpecDefault {
     cause: Cause[Any]
   )
 
-  override def spec: Spec[TestEnvironment, TestSuccess] =
+  override def spec =
     suite("Slf4jBridge")(
       test("logs through slf4j") {
         val testFailure = new RuntimeException("test error")
@@ -83,6 +83,11 @@ object Slf4jBridgeSpec extends ZIOSpecDefault {
             )
           )
         )
-      }.provide(Slf4jBridge.initialize)
-    )
+      },
+      test("Implements Logger#getName") {
+        for {
+          logger <- ZIO.attempt(org.slf4j.LoggerFactory.getLogger("zio.test.logger"))
+        } yield assertTrue(logger.getName == "zio.test.logger")
+      }
+    ).provide(Slf4jBridge.initialize) @@ TestAspect.sequential
 }


### PR DESCRIPTION
Current `org.slf4j.impl.ZioLogger` doesn't implement `Logger#getName` that causes a silent failure when using Netty, which rejects slf4j loggers without name.

