### PR TITLE
Fix StaticMarkerBinder implementation in slf4j-bridge

### DIFF
--- a/slf4j-bridge/src/main/scala/org/slf4j/impl/StaticMarkerBinder.scala
+++ b/slf4j-bridge/src/main/scala/org/slf4j/impl/StaticMarkerBinder.scala
@@ -5,11 +5,14 @@ import org.slf4j.helpers.BasicMarkerFactory
 import org.slf4j.spi.MarkerFactoryBinder
 
 class StaticMarkerBinder extends MarkerFactoryBinder {
-  override def getMarkerFactory: IMarkerFactory = StaticMarkerBinder.singleton
-  override def getMarkerFactoryClassStr: String = StaticMarkerBinder.className
+  private val markerFactory = new BasicMarkerFactory
+
+  override def getMarkerFactory: IMarkerFactory = markerFactory
+  override def getMarkerFactoryClassStr: String = classOf[BasicMarkerFactory].getName
 }
 
 object StaticMarkerBinder {
-  private val singleton = new BasicMarkerFactory
-  private val className = classOf[BasicMarkerFactory].getName
+  private val singleton = new StaticMarkerBinder
+
+  def getSingleton: StaticMarkerBinder = singleton
 }

--- a/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
+++ b/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
@@ -1,5 +1,7 @@
 package zio.logging.slf4j.bridge
 
+import org.slf4j.MarkerFactory
+import org.slf4j.impl.StaticMarkerBinder
 import zio.test._
 import zio.{ Cause, Chunk, LogLevel, ZIO }
 
@@ -88,6 +90,11 @@ object Slf4jBridgeSpec extends ZIOSpecDefault {
         for {
           logger <- ZIO.attempt(org.slf4j.LoggerFactory.getLogger("zio.test.logger"))
         } yield assertTrue(logger.getName == "zio.test.logger")
+      },
+      test("implements MarkerFactoryBinder") {
+        for {
+          markerFactory <- ZIO.attempt(MarkerFactory.getIMarkerFactory)
+        } yield assertTrue(markerFactory.eq(StaticMarkerBinder.getSingleton.getMarkerFactory))
       }
     ).provide(Slf4jBridge.initialize) @@ TestAspect.sequential
 }


### PR DESCRIPTION
I noticed this issue when using ZIO with Akka and attempted to route Akka logs via the `slf4j-bridge`. Akka calls `MarkerFactory.getIMarkerFactory`, which throws an exception in the existing implementation.