### PR TITLE
Log Metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,6 +145,7 @@ lazy val examples = project
     libraryDependencies ++= Seq(
       "ch.qos.logback"       % "logback-classic"          % logbackVersion,
       "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
+      "dev.zio"             %% "zio-metrics-connectors"   % "2.0.4",
       "dev.zio"            %%% "zio-test"                 % ZioVersion % Test,
       "dev.zio"            %%% "zio-test-sbt"             % ZioVersion % Test
     )

--- a/core/jvm/src/test/scala/zio/logging/MetricsSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/MetricsSpec.scala
@@ -1,0 +1,29 @@
+package zio.logging
+
+import zio.logging.test.TestService
+import zio.test._
+import zio.{ LogLevel, ZIO }
+
+object MetricsSpec extends ZIOSpecDefault {
+
+  val spec: Spec[Environment, Any] = suite("MetricsSpec")(
+    test("logs totals metrics") {
+      (for {
+        _            <- ZIO.logDebug("debug")
+        _            <- ZIO.logInfo("info")
+        _            <- ZIO.logWarning("warning")
+        _            <- TestService.testDebug
+        _            <- TestService.testInfo
+        _            <- TestService.testWarning
+        _            <- TestService.testError
+        debugCounter <- loggedTotalMetrics(LogLevel.Debug).value
+        infoCounter  <- loggedTotalMetrics(LogLevel.Info).value
+        warnCounter  <- loggedTotalMetrics(LogLevel.Warning).value
+        errorCounter <- loggedTotalMetrics(LogLevel.Error).value
+        fatalCounter <- loggedTotalMetrics(LogLevel.Fatal).value
+      } yield assertTrue(debugCounter.count == 2) && assertTrue(infoCounter.count == 2) && assertTrue(
+        warnCounter.count == 2
+      ) && assertTrue(errorCounter.count == 1) && assertTrue(fatalCounter.count == 0)).provideLayer(metrics)
+    }
+  )
+}

--- a/core/jvm/src/test/scala/zio/logging/MetricsSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/MetricsSpec.scala
@@ -21,9 +21,9 @@ object MetricsSpec extends ZIOSpecDefault {
         warnCounter  <- loggedTotalMetrics(LogLevel.Warning).value
         errorCounter <- loggedTotalMetrics(LogLevel.Error).value
         fatalCounter <- loggedTotalMetrics(LogLevel.Fatal).value
-      } yield assertTrue(debugCounter.count == 2) && assertTrue(infoCounter.count == 2) && assertTrue(
-        warnCounter.count == 2
-      ) && assertTrue(errorCounter.count == 1) && assertTrue(fatalCounter.count == 0)).provideLayer(metrics)
+      } yield assertTrue(debugCounter.count == 2d) && assertTrue(infoCounter.count == 2d) && assertTrue(
+        warnCounter.count == 2d
+      ) && assertTrue(errorCounter.count == 1d) && assertTrue(fatalCounter.count == 0d)).provideLayer(metrics)
     }
   )
 }

--- a/core/jvm/src/test/scala/zio/logging/MetricsSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/MetricsSpec.scala
@@ -23,7 +23,7 @@ object MetricsSpec extends ZIOSpecDefault {
         fatalCounter <- loggedTotalMetrics(LogLevel.Fatal).value
       } yield assertTrue(debugCounter.count == 2d) && assertTrue(infoCounter.count == 2d) && assertTrue(
         warnCounter.count == 2d
-      ) && assertTrue(errorCounter.count == 1d) && assertTrue(fatalCounter.count == 0d)).provideLayer(metrics)
+      ) && assertTrue(errorCounter.count == 1d) && assertTrue(fatalCounter.count == 0d)).provideLayer(logMetrics)
     }
   )
 }

--- a/core/shared/src/main/scala/zio/logging/package.scala
+++ b/core/shared/src/main/scala/zio/logging/package.scala
@@ -15,6 +15,8 @@
  */
 package zio
 
+import zio.metrics.Metric
+
 import java.io.PrintStream
 import java.nio.charset.{ Charset, StandardCharsets }
 import java.nio.file.Path
@@ -42,6 +44,18 @@ package object logging {
     zio.Unsafe.unsafe { implicit u =>
       FiberRef.unsafe.make(LogContext.empty, ZIO.identityFn[LogContext], (old, newV) => old ++ newV)
     }
+
+  private[logging] val loggedTotalMetrics =
+    List(
+      LogLevel.All,
+      LogLevel.Fatal,
+      LogLevel.Error,
+      LogLevel.Warning,
+      LogLevel.Info,
+      LogLevel.Debug,
+      LogLevel.Trace,
+      LogLevel.None
+    ).map(level => (level, Metric.counter(s"zio_logger_${level.label.toLowerCase}_total"))).toMap
 
   def console(
     format: LogFormat = LogFormat.colored,
@@ -299,4 +313,25 @@ package object logging {
     })
     stringLogger
   }
+
+  private val metricLogger = new ZLogger[String, Unit] {
+    override def apply(
+      trace: Trace,
+      fiberId: FiberId,
+      logLevel: LogLevel,
+      message: () => String,
+      cause: Cause[Any],
+      context: FiberRefs,
+      spans: List[LogSpan],
+      annotations: Map[String, String]
+    ): Unit = {
+      loggedTotalMetrics.get(logLevel).foreach { counter =>
+        val tags = context.get(FiberRef.currentTags).getOrElse(Set.empty)
+        counter.unsafe.update(1, tags)(Unsafe.unsafe)
+      }
+      ()
+    }
+  }
+
+  val metrics: ZLayer[Any, Nothing, Unit] = Runtime.addLogger(metricLogger)
 }

--- a/core/shared/src/main/scala/zio/logging/package.scala
+++ b/core/shared/src/main/scala/zio/logging/package.scala
@@ -333,5 +333,5 @@ package object logging {
     }
   }
 
-  val metrics: ZLayer[Any, Nothing, Unit] = Runtime.addLogger(metricLogger)
+  val logMetrics: ZLayer[Any, Nothing, Unit] = Runtime.addLogger(metricLogger)
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,7 +10,7 @@ which is responsible just for collecting metrics of all logs - `ZIO.log*` functi
 Metrics layer:
 
 ```scala
-val layer = zio.logging.metrics
+val layer = zio.logging.logMetrics
 ```
 
 Metrics:
@@ -36,7 +36,7 @@ You can find the source code [here](https://github.com/zio/zio-logging/tree/mast
 ```scala
 package zio.logging.example
 
-import zio.logging.{ LogFormat, console, metrics }
+import zio.logging.{ LogFormat, console, logMetrics }
 import zio.{ ExitCode, Runtime, Scope, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer }
 import zio.metrics.connectors.prometheus.{ prometheusLayer, publisherLayer, PrometheusPublisher }
 import zio.metrics.connectors.MetricsConfig
@@ -45,7 +45,7 @@ import zio._
 object MetricsApp extends ZIOAppDefault {
 
   override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] =
-    Runtime.removeDefaultLoggers >>> (console(LogFormat.default) ++ metrics)
+    Runtime.removeDefaultLoggers >>> (console(LogFormat.default) ++ logMetrics)
 
   override def run: ZIO[Scope, Any, ExitCode] =
     (for {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,82 @@
+---
+id: metrics
+title: "Log Metrics"
+---
+
+Log metrics collecting metrics related to ZIO logging (all `ZIO.log*` functions). 
+As ZIO core supporting multiple loggers, this logging metrics collector is implemented as specific `ZLogger` 
+which is responsible just for collecting metrics of all logs - `ZIO.log*` functions.
+
+Metrics layer:
+
+```scala
+val layer = zio.logging.metrics
+```
+
+Metrics:
+* zio_logger_all_total - logs count for `LogLevel.All`
+* zio_logger_fatal_total - logs count for `LogLevel.Fatal`
+* zio_logger_error_total - logs count for `LogLevel.Error`
+* zio_logger_warn_total - logs count for `LogLevel.Warning`
+* zio_logger_info_total - logs count for `LogLevel.Info`
+* zio_logger_debug_total - logs count for `LogLevel.Debug`
+* zio_logger_trace_total - logs count for `LogLevel.Trace`
+* zio_logger_none_total - logs count for `LogLevel.None`
+
+
+## Examples
+
+You can find the source code [here](https://github.com/zio/zio-logging/tree/master/examples/src/main/scala/zio/logging/example)
+
+
+### Console logger with metrics
+
+[//]: # (TODO: make snippet type-checked using mdoc)
+
+```scala
+package zio.logging.example
+
+import zio.logging.{ LogFormat, console, metrics }
+import zio.{ ExitCode, Runtime, Scope, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer }
+import zio.metrics.connectors.prometheus.{ prometheusLayer, publisherLayer, PrometheusPublisher }
+import zio.metrics.connectors.MetricsConfig
+import zio._
+
+object MetricsApp extends ZIOAppDefault {
+
+  override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] =
+    Runtime.removeDefaultLoggers >>> (console(LogFormat.default) ++ metrics)
+
+  override def run: ZIO[Scope, Any, ExitCode] =
+    (for {
+      _            <- ZIO.logInfo("Start")
+      _            <- ZIO.logWarning("Some warning")
+      _            <- ZIO.logError("Some error")
+      _            <- ZIO.logError("Another error")
+      _            <- ZIO.sleep(1.second)
+      metricValues <- ZIO.serviceWithZIO[PrometheusPublisher](_.get)
+      _            <- Console.printLine(metricValues)
+      _            <- ZIO.logInfo("Done")
+    } yield ExitCode.success)
+      .provideLayer((ZLayer.succeed(MetricsConfig(200.millis)) ++ publisherLayer) >+> prometheusLayer)
+
+}
+```
+
+Expected Console Output:
+```
+timestamp=2022-12-20T20:42:59.781481+01:00 level=INFO thread=zio-fiber-6 message="Start"
+timestamp=2022-12-20T20:42:59.810161+01:00 level=WARN thread=zio-fiber-6 message="Some warning"
+timestamp=2022-12-20T20:42:59.81197+01:00  level=ERROR thread=zio-fiber-6 message="Some error"
+timestamp=2022-12-20T20:42:59.813489+01:00 level=ERROR thread=zio-fiber-6 message="Another error"
+# TYPE zio_logger_warn_total counter
+# HELP zio_logger_warn_total Some help
+zio_logger_warn_total 1.0 1671565380643
+# TYPE zio_logger_info_total counter
+# HELP zio_logger_info_total Some help
+zio_logger_info_total 1.0 1671565380643
+# TYPE zio_logger_error_total counter
+# HELP zio_logger_error_total Some help
+zio_logger_error_total 2.0 1671565380643
+timestamp=2022-12-20T20:43:00.835177+01:00 level=INFO thread=zio-fiber-6 message="Done"
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -13,6 +13,7 @@ const sidebars = {
         'jpl',
         'slf4j',
         'slf4j-bridge',
+        'metrics',
         'testing'
       ]
     }

--- a/examples/src/main/scala/zio/logging/example/MetricsApp.scala
+++ b/examples/src/main/scala/zio/logging/example/MetricsApp.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019-2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio.logging.example
+
+import zio.logging.{ LogFormat, console, metrics }
+import zio.metrics.connectors.MetricsConfig
+import zio.metrics.connectors.prometheus.{ PrometheusPublisher, prometheusLayer, publisherLayer }
+import zio.{ ExitCode, Runtime, Scope, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer, _ }
+
+object MetricsApp extends ZIOAppDefault {
+
+  override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] =
+    Runtime.removeDefaultLoggers >>> (console(LogFormat.default) ++ metrics)
+
+  override def run: ZIO[Scope, Any, ExitCode] =
+    (for {
+      _            <- ZIO.logInfo("Start")
+      _            <- ZIO.logWarning("Some warning")
+      _            <- ZIO.logError("Some error")
+      _            <- ZIO.logError("Another error")
+      _            <- ZIO.sleep(1.second)
+      metricValues <- ZIO.serviceWithZIO[PrometheusPublisher](_.get)
+      _            <- Console.printLine(metricValues)
+      _            <- ZIO.logInfo("Done")
+    } yield ExitCode.success)
+      .provideLayer((ZLayer.succeed(MetricsConfig(200.millis)) ++ publisherLayer) >+> prometheusLayer)
+
+}

--- a/examples/src/main/scala/zio/logging/example/MetricsApp.scala
+++ b/examples/src/main/scala/zio/logging/example/MetricsApp.scala
@@ -15,7 +15,7 @@
  */
 package zio.logging.example
 
-import zio.logging.{ LogFormat, console, metrics }
+import zio.logging.{ LogFormat, console, logMetrics }
 import zio.metrics.connectors.MetricsConfig
 import zio.metrics.connectors.prometheus.{ PrometheusPublisher, prometheusLayer, publisherLayer }
 import zio.{ ExitCode, Runtime, Scope, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer, _ }
@@ -23,7 +23,7 @@ import zio.{ ExitCode, Runtime, Scope, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer, _
 object MetricsApp extends ZIOAppDefault {
 
   override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] =
-    Runtime.removeDefaultLoggers >>> (console(LogFormat.default) ++ metrics)
+    Runtime.removeDefaultLoggers >>> (console(LogFormat.default) ++ logMetrics)
 
   override def run: ZIO[Scope, Any, ExitCode] =
     (for {

--- a/examples/src/main/scala/zio/logging/example/SimpleApp.scala
+++ b/examples/src/main/scala/zio/logging/example/SimpleApp.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019-2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package zio.logging.example
 
 import zio.logging.{ LogFormat, console }


### PR DESCRIPTION
one of the zio logging related questions was: how to add counter/metric for error logs

As ZIO core supporting multiple loggers, this logging metrics collector is implemented as specific `ZLogger` 
which is responsible just for collecting metrics of all logs - `ZIO.log*` functions. (thanks to @vigoo for this idea)

metrics in form of counter for each log level, metric name:

zio_logger_${level.label.toLowerCase}_total
for example for LogLevel.Error: zio_logger_error_total

alternative solution for counter definition could be:

common metric name, for example zio_logger_log_total
log level in metric tags
