### PR TITLE
Idiomatic log metrics with customizable naming

### DIFF
--- a/core/jvm/src/test/scala/zio/logging/MetricsSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/MetricsSpec.scala
@@ -16,11 +16,11 @@ object MetricsSpec extends ZIOSpecDefault {
         _            <- TestService.testInfo
         _            <- TestService.testWarning
         _            <- TestService.testError
-        debugCounter <- loggedTotalMetrics(LogLevel.Debug).value
-        infoCounter  <- loggedTotalMetrics(LogLevel.Info).value
-        warnCounter  <- loggedTotalMetrics(LogLevel.Warning).value
-        errorCounter <- loggedTotalMetrics(LogLevel.Error).value
-        fatalCounter <- loggedTotalMetrics(LogLevel.Fatal).value
+        debugCounter <- loggedTotalMetric.tagged(DefaultLogLevelLabel, LogLevel.Debug.label.toLowerCase).value
+        infoCounter  <- loggedTotalMetric.tagged(DefaultLogLevelLabel, LogLevel.Info.label.toLowerCase).value
+        warnCounter  <- loggedTotalMetric.tagged(DefaultLogLevelLabel, LogLevel.Warning.label.toLowerCase).value
+        errorCounter <- loggedTotalMetric.tagged(DefaultLogLevelLabel, LogLevel.Error.label.toLowerCase).value
+        fatalCounter <- loggedTotalMetric.tagged(DefaultLogLevelLabel, LogLevel.Fatal.label.toLowerCase).value
       } yield assertTrue(debugCounter.count == 2d) && assertTrue(infoCounter.count == 2d) && assertTrue(
         warnCounter.count == 2d
       ) && assertTrue(errorCounter.count == 1d) && assertTrue(fatalCounter.count == 0d)).provideLayer(logMetrics)


### PR DESCRIPTION
The current impl. creates many metrics, which is not idiomatic. They are all the same metric with different notions. Therefore I propose to use labels instead with only one counter.
Also I think being forced to use a certain metric name is not good, since orgs might enforce naming conventions.

I remember, that we have the option for custom naming in other zio metrics too. I think it was zio-http.