### PR TITLE
slf4j bridge - logger name annotation

### DIFF
--- a/slf4j-bridge/src/main/scala-2/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala-2/org/slf4j/impl/ZioLogger.scala
@@ -1,13 +1,14 @@
 package org.slf4j.impl
 
 import org.slf4j.helpers.{ MessageFormatter, ZioLoggerBase }
+import zio.logging.slf4j.bridge.Slf4jBridge
 import zio.{ Cause, ZIO }
 
 class ZioLogger(name: String, factory: ZioLoggerFactory) extends ZioLoggerBase(name) {
 
   private def run(f: ZIO[Any, Nothing, Unit]): Unit =
     factory.run {
-      ZIO.logSpan(name)(f)
+      ZIO.logSpan(name)(ZIO.logAnnotate(Slf4jBridge.loggerNameAnnotationKey, name)(f))
     }
 
   override def isTraceEnabled: Boolean = true

--- a/slf4j-bridge/src/main/scala-3/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala-3/org/slf4j/impl/ZioLogger.scala
@@ -2,12 +2,13 @@ package org.slf4j.impl
 
 import org.slf4j.helpers.{ MessageFormatter, ZioLoggerBase }
 import zio.{ Cause, ZIO }
+import zio.logging.slf4j.bridge.Slf4jBridge
 
 class ZioLogger(name: String, factory: ZioLoggerFactory) extends ZioLoggerBase(name) {
 
   private def run(f: ZIO[Any, Nothing, Unit]): Unit =
     factory.run {
-      ZIO.logSpan(name)(f)
+      ZIO.logSpan(name)(ZIO.logAnnotate(Slf4jBridge.loggerNameAnnotationKey, name)(f))
     }
 
   override def isTraceEnabled: Boolean = true

--- a/slf4j-bridge/src/main/scala/zio/logging/slf4j/bridge/Slf4jBridge.scala
+++ b/slf4j-bridge/src/main/scala/zio/logging/slf4j/bridge/Slf4jBridge.scala
@@ -4,6 +4,9 @@ import org.slf4j.impl.ZioLoggerFactory
 import zio.{ ZIO, ZLayer }
 
 object Slf4jBridge {
+
+  val loggerNameAnnotationKey: String = "slf4j_logger_name"
+
   def initialize: ZLayer[Any, Nothing, Unit] =
     ZLayer {
       ZIO.runtime[Any].flatMap { runtime =>

--- a/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
+++ b/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
@@ -44,42 +44,42 @@ object Slf4jBridgeSpec extends ZIOSpecDefault {
             LogEntry(
               List("test.logger"),
               LogLevel.Debug,
-              Map.empty,
+              Map(Slf4jBridge.loggerNameAnnotationKey -> "test.logger"),
               "test debug message",
               Cause.empty
             ),
             LogEntry(
               List("test.logger"),
               LogLevel.Warning,
-              Map.empty,
+              Map(Slf4jBridge.loggerNameAnnotationKey -> "test.logger"),
               "hello world",
               Cause.empty
             ),
             LogEntry(
               List("test.logger"),
               LogLevel.Warning,
-              Map.empty,
+              Map(Slf4jBridge.loggerNameAnnotationKey -> "test.logger"),
               "3..2..1 ... go!",
               Cause.empty
             ),
             LogEntry(
               List("test.logger"),
               LogLevel.Warning,
-              Map.empty,
+              Map(Slf4jBridge.loggerNameAnnotationKey -> "test.logger"),
               "warn cause",
               Cause.die(testFailure)
             ),
             LogEntry(
               List("test.logger"),
               LogLevel.Error,
-              Map.empty,
+              Map(Slf4jBridge.loggerNameAnnotationKey -> "test.logger"),
               "error",
               Cause.die(testFailure)
             ),
             LogEntry(
               List("test.logger"),
               LogLevel.Error,
-              Map.empty,
+              Map(Slf4jBridge.loggerNameAnnotationKey -> "test.logger"),
               "error",
               Cause.empty
             )


### PR DESCRIPTION
fixes: #598

in case of sl4j-bridge reimplementation for zio-2

`ZIO.logSpan(name)` was used, (also probably at time of reimplementation, some things in relation to zio-2 logging design, was not clear)

in zio-1 version `log.locally(LogAnnotation.Name(nameList))(f)`

considering #598 and also current implementation of zio-logging, LogAnnotation is probably better way to propagate logger name

there is also a question if we should have `ZIO.logSpan(name)` for backward compatibility 


