### PR TITLE
Feature #612 - implement LogFilter glob-like wildcard support

### DIFF
--- a/core/jvm/src/test/scala/zio/logging/LogFilterSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/LogFilterSpec.scala
@@ -85,9 +85,14 @@ object LogFilterSpec extends ZIOSpecDefault {
 
       val filter: LogFilter[String] = LogFilter.logLevelByName(
         LogLevel.Debug,
-        "a"     -> LogLevel.Info,
-        "a.b.c" -> LogLevel.Warning,
-        "e.f"   -> LogLevel.Error
+        "a"         -> LogLevel.Info,
+        "a.b.c"     -> LogLevel.Warning,
+        "e.f"       -> LogLevel.Error,
+        "k.*.m"     -> LogLevel.Trace,
+        "k2.a*c.m2" -> LogLevel.Trace,
+        "k3.a*.m3"  -> LogLevel.Trace,
+        "k4.*c.m4"  -> LogLevel.Trace,
+        "q.**.t"    -> LogLevel.Trace
       )
 
       testFilter(filter, "x.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
@@ -98,7 +103,20 @@ object LogFilterSpec extends ZIOSpecDefault {
       testFilter(filter, "a.b.c.Exec.exec", LogLevel.Info, Assertion.isFalse) &&
       testFilter(filter, "a.b.c.Exec.exec", LogLevel.Warning, Assertion.isTrue) &&
       testFilter(filter, "e.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
-      testFilter(filter, "e.f.Exec.exec", LogLevel.Debug, Assertion.isFalse)
+      testFilter(filter, "e.f.Exec.exec", LogLevel.Debug, Assertion.isFalse) &&
+      testFilter(filter, "k.l.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
+      testFilter(filter, "k.l.m.Exec.exec", LogLevel.Trace, Assertion.isTrue) &&
+      testFilter(filter, "k2.alc.m2.Exec.exec", LogLevel.Trace, Assertion.isTrue) &&
+      testFilter(filter, "k3.alc.m3.Exec.exec", LogLevel.Trace, Assertion.isTrue) &&
+      testFilter(filter, "k3.lc.m3.Exec.exec", LogLevel.Trace, Assertion.isFalse) &&
+      testFilter(filter, "k4.alc.m4.Exec.exec", LogLevel.Trace, Assertion.isTrue) &&
+      testFilter(filter, "k4.al.m4.Exec.exec", LogLevel.Trace, Assertion.isFalse) &&
+      testFilter(filter, "k.l.l.m.Exec.exec", LogLevel.Trace, Assertion.isFalse) &&
+      testFilter(filter, "k.l.l.m.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
+      testFilter(filter, "q.r.s.t.Exec.exec", LogLevel.Trace, Assertion.isTrue) &&
+      testFilter(filter, "q.r.t.Exec.exec", LogLevel.Trace, Assertion.isTrue) &&
+      testFilter(filter, "q.r.s.u.Exec.exec", LogLevel.Trace, Assertion.isFalse) &&
+      testFilter(filter, "q.r.s.u.Exec.exec", LogLevel.Debug, Assertion.isTrue)
     },
     test("log filtering by log level and name with annotation") {
 

--- a/core/jvm/src/test/scala/zio/logging/LogFilterSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/LogFilterSpec.scala
@@ -88,11 +88,11 @@ object LogFilterSpec extends ZIOSpecDefault {
         "a"         -> LogLevel.Info,
         "a.b.c"     -> LogLevel.Warning,
         "e.f"       -> LogLevel.Error,
-        "k.*.m"     -> LogLevel.Trace,
-        "k2.a*c.m2" -> LogLevel.Trace,
-        "k3.a*.m3"  -> LogLevel.Trace,
-        "k4.*c.m4"  -> LogLevel.Trace,
-        "q.**.t"    -> LogLevel.Trace
+        "k.*.m"     -> LogLevel.Info,
+        "k2.a*c.m2" -> LogLevel.Info,
+        "k3.a*.m3"  -> LogLevel.Info,
+        "k4.*c.m4"  -> LogLevel.Info,
+        "q.**.t"    -> LogLevel.Info
       )
 
       testFilter(filter, "x.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
@@ -105,17 +105,20 @@ object LogFilterSpec extends ZIOSpecDefault {
       testFilter(filter, "e.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
       testFilter(filter, "e.f.Exec.exec", LogLevel.Debug, Assertion.isFalse) &&
       testFilter(filter, "k.l.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
-      testFilter(filter, "k.l.m.Exec.exec", LogLevel.Trace, Assertion.isTrue) &&
-      testFilter(filter, "k2.alc.m2.Exec.exec", LogLevel.Trace, Assertion.isTrue) &&
-      testFilter(filter, "k3.alc.m3.Exec.exec", LogLevel.Trace, Assertion.isTrue) &&
-      testFilter(filter, "k3.lc.m3.Exec.exec", LogLevel.Trace, Assertion.isFalse) &&
-      testFilter(filter, "k4.alc.m4.Exec.exec", LogLevel.Trace, Assertion.isTrue) &&
-      testFilter(filter, "k4.al.m4.Exec.exec", LogLevel.Trace, Assertion.isFalse) &&
-      testFilter(filter, "k.l.l.m.Exec.exec", LogLevel.Trace, Assertion.isFalse) &&
+      testFilter(filter, "k.l.m.Exec.exec", LogLevel.Debug, Assertion.isFalse) &&
+      testFilter(filter, "k.l.m.Exec.exec", LogLevel.Info, Assertion.isTrue) &&
       testFilter(filter, "k.l.l.m.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
-      testFilter(filter, "q.r.s.t.Exec.exec", LogLevel.Trace, Assertion.isTrue) &&
-      testFilter(filter, "q.r.t.Exec.exec", LogLevel.Trace, Assertion.isTrue) &&
-      testFilter(filter, "q.r.s.u.Exec.exec", LogLevel.Trace, Assertion.isFalse) &&
+      testFilter(filter, "k2.alc.m2.Exec.exec", LogLevel.Info, Assertion.isTrue) &&
+      testFilter(filter, "k3.alc.m3.Exec.exec", LogLevel.Info, Assertion.isTrue) &&
+      testFilter(filter, "k3.alc.m3.Exec.exec", LogLevel.Warning, Assertion.isTrue) &&
+      testFilter(filter, "k3.lc.m3.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
+      testFilter(filter, "k4.alc.m4.Exec.exec", LogLevel.Debug, Assertion.isFalse) &&
+      testFilter(filter, "k4.alc.m4.Exec.exec", LogLevel.Info, Assertion.isTrue) &&
+      testFilter(filter, "k4.al.m4.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
+      testFilter(filter, "q.r.t.Exec.exec", LogLevel.Debug, Assertion.isFalse) &&
+      testFilter(filter, "q.r.t.Exec.exec", LogLevel.Info, Assertion.isTrue) &&
+      testFilter(filter, "q.r.s.t.Exec.exec", LogLevel.Debug, Assertion.isFalse) &&
+      testFilter(filter, "q.r.s.t.Exec.exec", LogLevel.Info, Assertion.isTrue) &&
       testFilter(filter, "q.r.s.u.Exec.exec", LogLevel.Debug, Assertion.isTrue)
     },
     test("log filtering by log level and name with annotation") {

--- a/core/jvm/src/test/scala/zio/logging/LogFilterSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/LogFilterSpec.scala
@@ -90,9 +90,11 @@ object LogFilterSpec extends ZIOSpecDefault {
         "e.f"       -> LogLevel.Error,
         "k.*.m"     -> LogLevel.Info,
         "k2.a*c.m2" -> LogLevel.Info,
-        "k3.a*.m3"  -> LogLevel.Info,
+        "k3.a*.m3"  -> LogLevel.Trace,
+        "k3.alc.m3" -> LogLevel.Warning,
         "k4.*c.m4"  -> LogLevel.Info,
-        "q.**.t"    -> LogLevel.Info
+        "q.**.t"    -> LogLevel.Warning,
+        "q.**.t.u"  -> LogLevel.Info
       )
 
       testFilter(filter, "x.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
@@ -109,16 +111,17 @@ object LogFilterSpec extends ZIOSpecDefault {
       testFilter(filter, "k.l.m.Exec.exec", LogLevel.Info, Assertion.isTrue) &&
       testFilter(filter, "k.l.l.m.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
       testFilter(filter, "k2.alc.m2.Exec.exec", LogLevel.Info, Assertion.isTrue) &&
-      testFilter(filter, "k3.alc.m3.Exec.exec", LogLevel.Info, Assertion.isTrue) &&
+      testFilter(filter, "k3.alc.m3.Exec.exec", LogLevel.Info, Assertion.isFalse) &&
       testFilter(filter, "k3.alc.m3.Exec.exec", LogLevel.Warning, Assertion.isTrue) &&
       testFilter(filter, "k3.lc.m3.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
       testFilter(filter, "k4.alc.m4.Exec.exec", LogLevel.Debug, Assertion.isFalse) &&
       testFilter(filter, "k4.alc.m4.Exec.exec", LogLevel.Info, Assertion.isTrue) &&
       testFilter(filter, "k4.al.m4.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
-      testFilter(filter, "q.r.t.Exec.exec", LogLevel.Debug, Assertion.isFalse) &&
-      testFilter(filter, "q.r.t.Exec.exec", LogLevel.Info, Assertion.isTrue) &&
-      testFilter(filter, "q.r.s.t.Exec.exec", LogLevel.Debug, Assertion.isFalse) &&
-      testFilter(filter, "q.r.s.t.Exec.exec", LogLevel.Info, Assertion.isTrue) &&
+      testFilter(filter, "q.r.t.Exec.exec", LogLevel.Info, Assertion.isFalse) &&
+      testFilter(filter, "q.r.t.Exec.exec", LogLevel.Warning, Assertion.isTrue) &&
+      testFilter(filter, "q.r.s.t.Exec.exec", LogLevel.Info, Assertion.isFalse) &&
+      testFilter(filter, "q.r.s.t.Exec.exec", LogLevel.Warning, Assertion.isTrue) &&
+      testFilter(filter, "q.r.s.t.u.Exec.exec", LogLevel.Info, Assertion.isTrue)
       testFilter(filter, "q.r.s.u.Exec.exec", LogLevel.Debug, Assertion.isTrue)
     },
     test("log filtering by log level and name with annotation") {

--- a/core/jvm/src/test/scala/zio/logging/LogFilterSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/LogFilterSpec.scala
@@ -120,8 +120,8 @@ object LogFilterSpec extends ZIOSpecDefault {
         testFilter(filter, "a.b.c.Exec.exec", LogLevel.Warning, Assertion.isTrue) &&
         testFilter(filter, "a.b2.c.Exec.exec", LogLevel.Warning, Assertion.isTrue) &&
         testFilter(filter, "e.Exec.exec", LogLevel.Debug, Assertion.isTrue) &&
-        testFilter(filter, "e.f.Exec.exec", LogLevel.Debug, Assertion.isFalse) &&
-        testFilter(filter, "e.f.Exec.exec", LogLevel.Error, Assertion.isTrue)
+        testFilter(filter, "e.f.g.Exec.exec", LogLevel.Debug, Assertion.isFalse) &&
+        testFilter(filter, "e.f.g.Exec.exec", LogLevel.Error, Assertion.isTrue)
       },
       test("any string and globstar patterns") {
         val filter: LogFilter[String] = LogFilter.logLevelByName(

--- a/core/jvm/src/test/scala/zio/logging/LogFilterSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/LogFilterSpec.scala
@@ -366,6 +366,38 @@ object LogFilterSpec extends ZIOSpecDefault {
           "a"              -> LogLevel.Info,
           "a"              -> LogLevel.Warning
         )
+      ) &&
+      check(
+        Seq(
+          "a"               -> LogLevel.Warning,
+          "a"               -> LogLevel.Info,
+          "**"              -> LogLevel.Info,
+          "*"               -> LogLevel.Info,
+          "a.**.c.Service1" -> LogLevel.Warning,
+          "a.b.c.Service1"  -> LogLevel.Warning,
+          "a.*.c.Service1"  -> LogLevel.Warning,
+          "a.b.c"           -> LogLevel.Error,
+          "a.b.d"           -> LogLevel.Debug,
+          "e.f"             -> LogLevel.Error,
+          "e.*.g.*.i"       -> LogLevel.Error,
+          "e.*.g.h.*"       -> LogLevel.Error,
+          "e.f.*.h"         -> LogLevel.Error
+        ),
+        Seq(
+          "e.f.*.h"         -> LogLevel.Error,
+          "e.f"             -> LogLevel.Error,
+          "e.*.g.h.*"       -> LogLevel.Error,
+          "e.*.g.*.i"       -> LogLevel.Error,
+          "a.b.d"           -> LogLevel.Debug,
+          "a.b.c.Service1"  -> LogLevel.Warning,
+          "a.b.c"           -> LogLevel.Error,
+          "a.*.c.Service1"  -> LogLevel.Warning,
+          "a.**.c.Service1" -> LogLevel.Warning,
+          "a"               -> LogLevel.Info,
+          "a"               -> LogLevel.Warning,
+          "*"               -> LogLevel.Info,
+          "**"              -> LogLevel.Info
+        )
       )
     }
   )

--- a/core/shared/src/main/scala/zio/logging/LogFilter.scala
+++ b/core/shared/src/main/scala/zio/logging/LogFilter.scala
@@ -292,24 +292,27 @@ object LogFilter {
       case (l @ (lh :: ls), m @ (mh :: ms)) =>
         l.startsWith(m) ||
           (m.span(g => !g.contains("*")) match {
-            case (_, Nil)                => false
-            case (m0, "**" :: Nil)       => true
-            case (Nil, "*" :: m)         =>
+            case (_, Nil)          => false
+            case (m0, "**" :: Nil) => true
+            case (Nil, "*" :: m)   =>
               // we drop lh which is matched by '*'
               compareRoutes(ls, m)
-            case (m0, "*" :: m)          =>
+
+            case (m0, "*" :: m) =>
               // match the m0 part and remove it from the list before the compare the remainder
               l.startsWith(m0) && (l.drop(m0.size) match {
                 case Nil      => false
                 case lh :: ls => compareRoutes(ls, m)
               })
+
             case (Nil, "**" :: mh :: ms) =>
               // remove any paths not matching the mh part
               l.dropWhile(_ != mh) match {
                 case Nil      => false // we didn't find a match so this route is invalid
                 case lh :: ls => compareRoutes(ls, ms)
               }
-            case (m0, "**" :: mh :: ms)  =>
+
+            case (m0, "**" :: mh :: ms) =>
               // match the m0 part and remove it from the list before the compare the remainder
               l.startsWith(m0) && (
                 ls.dropWhile(_ != mh) match {
@@ -317,7 +320,8 @@ object LogFilter {
                   case lh :: ls => compareRoutes(ls, ms)
                 }
               )
-            case (m0, s"$s*$e" :: m)     =>
+
+            case (m0, s"$s*$e" :: m) =>
               // match the m0 part and remove it from the list before the compare the remainder
               l.startsWith(m0) && (l.drop(m0.size) match {
                 case Nil      => false
@@ -325,6 +329,8 @@ object LogFilter {
                   // check if lh starts with s, strip it (we don't want overlap) and ends with e, then the compare the remainder
                   lh.startsWith(s) && lh.stripPrefix(s).endsWith(e) && compareRoutes(ls, m)
               })
+
+            case _ => false // should not happen, to dismiss exhaustiveness warning
           })
     }
 

--- a/core/shared/src/main/scala/zio/logging/LogFilter.scala
+++ b/core/shared/src/main/scala/zio/logging/LogFilter.scala
@@ -404,8 +404,10 @@ object LogFilter {
           val r = yFirst.compareTo(xFirst)
           if (r != 0) {
             if (xFirst.contains('*') || yFirst.contains('*')) {
-              if (Set("**", "*").contains(xFirst)) 1
-              else if (Set("**", "*").contains(yFirst)) -1
+              if (xFirst == "**") 1
+              else if (yFirst == "**") -1
+              else if (xFirst == "*") 1
+              else if (yFirst == "*") -1
               else
                 compareNames(xFirst.split('*').toList.filter(_.nonEmpty), yFirst.split('*').toList.filter(_.nonEmpty))
             } else r

--- a/core/shared/src/main/scala/zio/logging/LogFilter.scala
+++ b/core/shared/src/main/scala/zio/logging/LogFilter.scala
@@ -285,59 +285,38 @@ object LogFilter {
     val nameGroup      = group.map(splitNameByDot)
 
     @tailrec
-    def compareRoutes(l: List[String], m: List[String]): Boolean = (l, m) match {
-      case (Nil, Nil)                       => true
-      case (Nil, _)                         => false
-      case (l, Nil)                         => true
-      case (l @ (lh :: ls), m @ (mh :: ms)) =>
-        l.startsWith(m) ||
-          (m.span(g => !g.contains("*")) match {
-            case (_, Nil)          => false
-            case (m0, "**" :: Nil) => true
-            case (Nil, "*" :: m)   =>
-              // we drop lh which is matched by '*'
-              compareRoutes(ls, m)
+    def globStarCompare(l: List[String], m: List[String]): Boolean =
+      (l, m) match {
+        case (_, Nil)           => true
+        case (Nil, _)           => false
+        case (l @ (_ :: ls), m) =>
+          // try a regular, routesCompare or check if skipping paths (globstar pattern) results in a matching path
+          l.startsWith(m) || compareRoutes(l, m) || globStarCompare(ls, m)
+      }
 
-            case (m0, "*" :: m) =>
-              // match the m0 part and remove it from the list before the compare the remainder
-              l.startsWith(m0) && (l.drop(m0.size) match {
-                case Nil      => false
-                case lh :: ls => compareRoutes(ls, m)
-              })
-
-            case (Nil, "**" :: mh :: ms) =>
-              // remove any paths not matching the mh part
-              l.dropWhile(_ != mh) match {
-                case Nil      => false // we didn't find a match so this route is invalid
-                case lh :: ls => compareRoutes(ls, ms)
-              }
-
-            case (m0, "**" :: mh :: ms) =>
-              // match the m0 part and remove it from the list before the compare the remainder
-              l.startsWith(m0) && (
-                ls.dropWhile(_ != mh) match {
-                  case Nil      => false
-                  case lh :: ls => compareRoutes(ls, ms)
-                }
-              )
-
-            case (m0, s"$s*$e" :: m) =>
-              // match the m0 part and remove it from the list before the compare the remainder
-              l.startsWith(m0) && (l.drop(m0.size) match {
-                case Nil      => false
-                case lh :: ls =>
-                  // check if lh starts with s, strip it (we don't want overlap) and ends with e, then the compare the remainder
-                  lh.startsWith(s) && lh.stripPrefix(s).endsWith(e) && compareRoutes(ls, m)
-              })
-
-            case _ => false // should not happen, to dismiss exhaustiveness warning
-          })
-    }
+    @tailrec
+    def compareRoutes(l: List[String], m: List[String]): Boolean =
+      (l, m) match {
+        case (_, Nil)                                  => true
+        case (Nil, _)                                  => false
+        case (_ :: Nil, "*" :: Nil)                    => true
+        case (l, "**" :: ms)                           =>
+          globStarCompare(l, ms)
+        case (lh :: ls, mh :: ms) if !mh.contains("*") =>
+          lh == mh && compareRoutes(ls, ms)
+        case (l @ (lh :: ls), m @ (mh :: ms))          =>
+          mh.split('*')
+            .toList
+            .foldLeft((true, lh)) { case ((matchResult, name), p) =>
+              (matchResult && name.contains(p)) -> name.split(p).tail.mkString
+            }
+            ._1 && compareRoutes(ls, ms)
+      }
 
     logLevelByGroup[M, List[String]](
       rootLevel,
       nameGroup,
-      (l, m) => compareRoutes(l, m),
+      (l, m) => l.startsWith(m) || compareRoutes(l, m),
       mappingsSorted: _*
     )
   }
@@ -421,7 +400,11 @@ object LogFilter {
         case (xFirst :: xTail, yFirst :: yTail) =>
           val r = yFirst.compareTo(xFirst)
           if (r != 0) {
-            r
+            if (xFirst.contains('*') || yFirst.contains('*')) {
+              if (Set("**", "*").contains(xFirst)) 1
+              else if (Set("**", "*").contains(yFirst)) -1
+              else compareNames(xFirst.split('*').toList, yFirst.split('*').toList)
+            } else r
           } else compareNames(xTail, yTail)
 
         case _ => 0

--- a/docs/log-filter.md
+++ b/docs/log-filter.md
@@ -16,12 +16,14 @@ import zio.logging.LogFilter
 val filter = LogFilter.logLevelByName(
     LogLevel.Debug,
     "io.netty" -> LogLevel.Info, 
-    "io.grpc.netty" -> LogLevel.Info
+    "io.grpc.netty" -> LogLevel.Info,
+    "org.my.**.ServiceX" -> LogLevel.Trace, // glob-like (any paths) filter
+    "org.my.X*Layers" -> LogLevel.Info // glob-like (single or partial path) filter
 )
 ```
 
 will use the `Debug` log level for everything except for log events with the logger name
-prefixed by either `List("io", "netty")` or `List("io", "grpc", "netty")`.
+prefixed by either `List("io", "netty")` or `List("io", "grpc", "netty")` or `List("org", "my", "**", "ServiceX")` or `List("org", "my", "X*Layers")`.
 Logger name is extracted from log annotation or `zio.Trace`.
 
 `LogFilter.filter` returns a version of `zio.ZLogger` that only logs messages when this filter is satisfied.


### PR DESCRIPTION
#612

I implemented `**` (any number of paths) and `*` (any (partial) path) within the existing LogFilter path structure `List[String]`. 

I think this could be optimized if the LogFilters were used in a nested map-like structure. 

Another way would be the use regex.