### PR TITLE
slf4j backend - invoke slf4j initialisation

### DIFF
--- a/examples/src/main/scala/zio/logging/example/Slf4jFailureApp.scala
+++ b/examples/src/main/scala/zio/logging/example/Slf4jFailureApp.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019-2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio.logging.example
+
+import zio.logging.backend.SLF4J
+import zio.{ Runtime, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer }
+
+object Slf4jFailureApp extends ZIOAppDefault {
+
+  override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] = Runtime.removeDefaultLoggers >>> SLF4J.slf4j
+
+  def run: ZIO[Any, Throwable, Unit] =
+    ZIO.dieMessage("die") <&> ZIO.unit
+}

--- a/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
@@ -204,7 +204,11 @@ object SLF4J {
   def slf4jLogger(
     format: LogFormat,
     loggerName: Trace => String
-  ): ZLogger[String, Unit] =
+  ): ZLogger[String, Unit] = {
+    // get some slf4j logger to invoke slf4j initialisation
+    // as in some program failure cases it may happen, that program exit sooner then log message will be logged (#616)
+    LoggerFactory.getLogger("zio-slf4j-logger")
+
     new ZLogger[String, Unit] {
       override def apply(
         trace: Trace,
@@ -229,5 +233,6 @@ object SLF4J {
         ()
       }
     }
+  }
 
 }


### PR DESCRIPTION
Fixes: #616 

it is look like that program will end sooner then slf4j log system is initialised and message logged, in cases when failure is first log in application

adding `LoggerFactory.getLogger("zio-slf4j-logger")` to slf4j layer should invoke initialisation of slf4j log system