### PR TITLE
Document the usage of `Slf4j.slf4j` layer

### DIFF
--- a/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
@@ -187,17 +187,29 @@ object SLF4J {
   ): ZLayer[Any, Nothing, Unit] =
     slf4j(logLevel, logFormatDefault, getLoggerName())
 
+  /**
+   * Use this layer to register an use an Slf4j logger in your app.
+   * To avoid double logging, you should create this layer only once in your application
+   */
   def slf4j(
     format: LogFormat,
     loggerName: Trace => String
   ): ZLayer[Any, Nothing, Unit] =
     Runtime.addLogger(slf4jLogger(format, loggerName))
 
+  /**
+   * Use this layer to register an use an Slf4j logger in your app.
+   * To avoid double logging, you should create this layer only once in your application
+   */
   def slf4j(
     format: LogFormat
   ): ZLayer[Any, Nothing, Unit] =
     slf4j(format, getLoggerName())
 
+  /**
+   * Use this layer to register an use an Slf4j logger in your app.
+   * To avoid double logging, you should create this layer only once in your application
+   */
   def slf4j: ZLayer[Any, Nothing, Unit] =
     slf4j(logFormatDefault)
 


### PR DESCRIPTION
We had an issue with double logging due to the presence of 2 such layers in our application, and it took a while to discover the root cause. Such a documentation could help other devs in the same situation.