### PR TITLE
Logger name annotation

### DIFF
--- a/core/jvm/src/test/scala/zio/logging/LogFilterSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/LogFilterSpec.scala
@@ -32,7 +32,7 @@ object LogFilterSpec extends ZIOSpecDefault {
         Cause.empty,
         FiberRefs.empty,
         List.empty,
-        Map("name" -> location)
+        Map(loggerNameAnnotationKey -> location)
       )
     )(
       expectation ?? s"$location with $level"
@@ -102,7 +102,7 @@ object LogFilterSpec extends ZIOSpecDefault {
     },
     test("log filtering by log level and name with annotation") {
 
-      val loggerName: LogGroup[Any, String] = LoggerNameExtractor.annotation("name").toLogGroup()
+      val loggerName: LogGroup[Any, String] = LoggerNameExtractor.loggerNameAnnotationOrTrace.toLogGroup()
 
       val filter: LogFilter[String] = LogFilter.logLevelByGroup(
         LogLevel.Debug,
@@ -124,7 +124,7 @@ object LogFilterSpec extends ZIOSpecDefault {
     },
     test("log filtering by log level and name matcher with annotation") {
 
-      val loggerName: LogGroup[Any, String] = LoggerNameExtractor.annotation("name").toLogGroup()
+      val loggerName: LogGroup[Any, String] = LoggerNameExtractor.loggerNameAnnotationOrTrace.toLogGroup()
 
       val filter: LogFilter[String] = LogFilter.logLevelByGroup(
         LogLevel.Debug,

--- a/core/jvm/src/test/scala/zio/logging/LogFormatSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/LogFormatSpec.scala
@@ -5,12 +5,10 @@ import zio.{ Cause, FiberId, FiberRefs, LogLevel, Trace }
 
 import java.util.UUID
 
-import LogFormat.{ level, line, _ }
-
 object LogFormatSpec extends ZIOSpecDefault {
   val spec: Spec[Environment, Any] = suite("LogFormatSpec")(
     test("line") {
-      val format = line
+      val format = LogFormat.line
       check(Gen.string) { line =>
         val result = format
           .toLogger(
@@ -27,7 +25,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("level") {
-      val format = level
+      val format = LogFormat.level
       check(Gen.elements(LogLevel.Info, LogLevel.Warning, LogLevel.Error, LogLevel.Debug)) { level =>
         val result =
           format.toLogger(
@@ -44,7 +42,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("levelSyslog") {
-      val format = levelSyslog
+      val format = LogFormat.levelSyslog
       check(Gen.elements(LogLevel.Info, LogLevel.Warning, LogLevel.Error, LogLevel.Debug)) { level =>
         val result =
           format.toLogger(
@@ -61,7 +59,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("fiberId") {
-      val format = fiberId
+      val format = LogFormat.fiberId
       check(Gen.int, Gen.int) { (seq, time) =>
         val result = format.toLogger(
           Trace.empty,
@@ -77,7 +75,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("loggerName") {
-      val format = loggerName(LoggerNameExtractor.annotation("name"))
+      val format = LogFormat.loggerName(LoggerNameExtractor.annotation("name"))
       check(Gen.string) { annotationValue =>
         val result = format.toLogger(
           Trace.empty,
@@ -93,7 +91,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("annotation") {
-      val format = annotation("test")
+      val format = LogFormat.annotation("test")
       check(Gen.string) { annotationValue =>
         val result = format.toLogger(
           Trace.empty,
@@ -109,7 +107,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("annotation (structured)") {
-      val format = annotation(LogAnnotation.UserId)
+      val format = LogFormat.annotation(LogAnnotation.UserId)
       check(Gen.string) { annotationValue =>
         val result = format.toLogger(
           Trace.empty,
@@ -128,7 +126,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("empty annotation") {
-      val format = annotation("test")
+      val format = LogFormat.annotation("test")
       val result = format.toLogger(
         Trace.empty,
         FiberId.None,
@@ -142,7 +140,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       assertTrue(result == "")
     },
     test("allAnnotations") {
-      val format = allAnnotations
+      val format = LogFormat.allAnnotations
       check(Gen.string) { annotationValue =>
         val result = format.toLogger(
           Trace.empty,
@@ -161,7 +159,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("allAnnotations with exclusion") {
-      val format = allAnnotations(excludeKeys = Set("test2", LogAnnotation.TraceId.name))
+      val format = LogFormat.allAnnotations(excludeKeys = Set("test2", LogAnnotation.TraceId.name))
       check(Gen.string) { annotationValue =>
         val result = format.toLogger(
           Trace.empty,
@@ -182,7 +180,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("enclosing class") {
-      val format = enclosingClass
+      val format = LogFormat.enclosingClass
       val result = format
         .toLogger(
           implicitly[Trace],
@@ -197,7 +195,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       assertTrue(result == "")
     } @@ TestAspect.ignore,
     test("string concat") {
-      val format = text("a") + line + text("c")
+      val format = LogFormat.text("a") + LogFormat.line + LogFormat.text("c")
       check(Gen.string) { line =>
         val result = format
           .toLogger(
@@ -214,7 +212,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("spaced") {
-      val format = line |-| text("c")
+      val format = LogFormat.line |-| LogFormat.text("c")
       check(Gen.string) { line =>
         val result = format
           .toLogger(
@@ -231,7 +229,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("colored") {
-      val format = line.color(LogColor.RED)
+      val format = LogFormat.line.color(LogColor.RED)
       check(Gen.string) { line =>
         val result = format
           .toLogger(
@@ -248,7 +246,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("fixed") {
-      val format = line.fixed(10)
+      val format = LogFormat.line.fixed(10)
       check(Gen.string) { line =>
         val result = format.toLogger(
           Trace.empty,
@@ -264,7 +262,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("traceLine") {
-      val format = traceLine
+      val format = LogFormat.traceLine
       check(Gen.int) { tLine =>
         val result = format.toLogger(
           Trace("location", "file", tLine),
@@ -280,7 +278,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("cause") {
-      val format = cause
+      val format = LogFormat.cause
       check(Gen.string) { msg =>
         val failure = Cause.fail(new Exception(msg))
         val result  = format.toLogger(
@@ -297,7 +295,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("cause empty") {
-      val format = cause
+      val format = LogFormat.cause
 
       val failure = Cause.empty
       val result  = format.toLogger(
@@ -313,7 +311,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       assertTrue(result == failure.prettyPrint)
     },
     test("not empty cause with label if not empty") {
-      val format = (label("cause", cause)).filter(LogFilter.causeNonEmpty)
+      val format = (LogFormat.label("cause", LogFormat.cause)).filter(LogFilter.causeNonEmpty)
       check(Gen.string) { msg =>
         val failure = Cause.fail(new Exception(msg))
         val result  = format.toLogger(
@@ -330,7 +328,7 @@ object LogFormatSpec extends ZIOSpecDefault {
       }
     },
     test("empty cause with label if not empty") {
-      val format = label("cause", cause).filter(LogFilter.causeNonEmpty)
+      val format = LogFormat.label("cause", LogFormat.cause).filter(LogFilter.causeNonEmpty)
 
       val failure = Cause.empty
       val result  = format.toLogger(
@@ -346,10 +344,10 @@ object LogFormatSpec extends ZIOSpecDefault {
       assertTrue(result == "")
     },
     test("default without timestamp") {
-      val format = label("level", level) |-|
-        label("thread", fiberId) |-|
-        label("message", quoted(line)) +
-        (space + label("cause", cause)).filter(LogFilter.causeNonEmpty)
+      val format = LogFormat.label("level", LogFormat.level) |-|
+        LogFormat.label("thread", LogFormat.fiberId) |-|
+        LogFormat.label("message", LogFormat.quoted(LogFormat.line)) +
+        (LogFormat.space + LogFormat.label("cause", LogFormat.cause)).filter(LogFilter.causeNonEmpty)
 
       check(Gen.int, Gen.string, Gen.string, Gen.boolean) { (fiberId, message, cause, hasCause) =>
         val failure                    = if (hasCause) Cause.fail(new Exception(cause)) else Cause.empty
@@ -376,7 +374,7 @@ object LogFormatSpec extends ZIOSpecDefault {
         _.startsWith("EXCLUDE#")
       )
 
-      val format = line.filter(filter)
+      val format = LogFormat.line.filter(filter)
       check(Gen.alphaNumericString, Gen.boolean) { (msg, hasExclude) =>
         val message  = if (hasExclude) "EXCLUDE#" + msg else msg
         val expected = if (hasExclude) message else ""

--- a/core/jvm/src/test/scala/zio/logging/LogGroupSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/LogGroupSpec.scala
@@ -21,7 +21,7 @@ object LogGroupSpec extends ZIOSpecDefault {
         assertTrue(result == level)
       }
     },
-    test("loggerName") {
+    test("loggerName with trace") {
       val group = LogGroup.loggerName
       check(Gen.alphaNumericString) { value =>
         val result = group(
@@ -33,6 +33,22 @@ object LogGroupSpec extends ZIOSpecDefault {
           FiberRefs.empty,
           Nil,
           Map.empty
+        )
+        assertTrue(result == value)
+      }
+    },
+    test("loggerName with logger name annotation") {
+      val group = LogGroup.loggerName
+      check(Gen.alphaNumericString) { value =>
+        val result = group(
+          Trace.empty,
+          FiberId.None,
+          LogLevel.Info,
+          () => "",
+          Cause.empty,
+          FiberRefs.empty,
+          Nil,
+          Map(loggerNameAnnotationKey -> value)
         )
         assertTrue(result == value)
       }

--- a/core/shared/src/main/scala/zio/logging/LogFilter.scala
+++ b/core/shared/src/main/scala/zio/logging/LogFilter.scala
@@ -256,7 +256,7 @@ object LogFilter {
    *
    * will use the `Debug` log level for everything except for log events with the logger name
    * prefixed by either `List("io", "netty")` or `List("io", "grpc", "netty")`.
-   * Logger name is extracted from [[Trace]].
+   * Logger name is extracted from log annotation or [[Trace]], see: [[LogGroup.loggerName]]
    *
    * @param rootLevel Minimum log level for the root node
    * @param mappings  List of mappings, nesting defined by dot-separated strings

--- a/core/shared/src/main/scala/zio/logging/LogGroup.scala
+++ b/core/shared/src/main/scala/zio/logging/LogGroup.scala
@@ -161,14 +161,14 @@ object LogGroup {
   /**
    * Log group by logger name
    *
-   * Logger name is extracted from [[Trace]]
+   * Logger name is extracted from annotation or [[Trace]]
    */
-  val loggerName: LogGroup[Any, String] = fromLoggerNameExtractor(LoggerNameExtractor.trace)
+  val loggerName: LogGroup[Any, String] = LoggerNameExtractor.loggerNameAnnotationOrTrace.toLogGroup()
 
   /**
    * Log group by logger name and log level
    *
-   * Logger name is extracted from [[Trace]]
+   * Logger name is extracted from annotation or [[Trace]]
    */
   val loggerNameAndLevel: LogGroup[Any, (String, LogLevel)] = loggerName ++ logLevel
 

--- a/core/shared/src/main/scala/zio/logging/LogGroup.scala
+++ b/core/shared/src/main/scala/zio/logging/LogGroup.scala
@@ -161,7 +161,7 @@ object LogGroup {
   /**
    * Log group by logger name
    *
-   * Logger name is extracted from annotation or [[Trace]]
+   * Logger name is extracted from annotation or [[Trace]], see: [[LoggerNameExtractor.loggerNameAnnotationOrTrace]]
    */
   val loggerName: LogGroup[Any, String] = LoggerNameExtractor.loggerNameAnnotationOrTrace.toLogGroup()
 

--- a/core/shared/src/main/scala/zio/logging/LoggerNameExtractor.scala
+++ b/core/shared/src/main/scala/zio/logging/LoggerNameExtractor.scala
@@ -86,7 +86,6 @@ object LoggerNameExtractor {
 
   /**
    * Extractor which take logger name from annotation with key [[zio.logging.loggerNameAnnotationKey]] or [[Trace]] if specified annotation is not present
-   *
    */
   val loggerNameAnnotationOrTrace: LoggerNameExtractor =
     annotationOrTrace(loggerNameAnnotationKey)

--- a/core/shared/src/main/scala/zio/logging/LoggerNameExtractor.scala
+++ b/core/shared/src/main/scala/zio/logging/LoggerNameExtractor.scala
@@ -53,21 +53,6 @@ trait LoggerNameExtractor { self =>
 object LoggerNameExtractor {
 
   /**
-   * Extractor which take logger name from annotation
-   *
-   * @param name name of annotation
-   */
-  def annotation(name: String): LoggerNameExtractor = (_, _, annotations) => annotations.get(name)
-
-  /**
-   * Extractor which take logger name from annotation or [[Trace]] if specified annotation is not present
-   *
-   * @param name name of annotation
-   */
-  def annotationOrTrace(name: String): LoggerNameExtractor =
-    annotation(name) || trace
-
-  /**
    * Extractor which take logger name from [[Trace]]
    *
    * trace with value ''example.LivePingService.ping(PingService.scala:22)''
@@ -83,5 +68,27 @@ object LoggerNameExtractor {
         Some(name)
       case _                     => None
     }
+
+  /**
+   * Extractor which take logger name from annotation
+   *
+   * @param name name of annotation
+   */
+  def annotation(name: String): LoggerNameExtractor = (_, _, annotations) => annotations.get(name)
+
+  /**
+   * Extractor which take logger name from annotation or [[Trace]] if specified annotation is not present
+   *
+   * @param name name of annotation
+   */
+  def annotationOrTrace(name: String): LoggerNameExtractor =
+    annotation(name) || LoggerNameExtractor.trace
+
+  /**
+   * Extractor which take logger name from annotation with key [[zio.logging.loggerNameAnnotationKey]] or [[Trace]] if specified annotation is not present
+   *
+   */
+  val loggerNameAnnotationOrTrace: LoggerNameExtractor =
+    annotationOrTrace(loggerNameAnnotationKey)
 
 }

--- a/core/shared/src/main/scala/zio/logging/package.scala
+++ b/core/shared/src/main/scala/zio/logging/package.scala
@@ -45,10 +45,23 @@ package object logging {
       FiberRef.unsafe.make(LogContext.empty, ZIO.identityFn[LogContext], (old, newV) => old ++ newV)
     }
 
+  /**
+   * log aspect annotation key for logger name
+   */
+  val loggerNameAnnotationKey = "logger_name"
+
   private[logging] val logLevelMetricLabel = "level"
 
   private[logging] val loggedTotalMetric =
     Metric.counter(name = "zio_log_total")
+
+  /**
+   * Logger name aspect, by this aspect is possible to set logger name (in general, logger name is extracted from [[Trace]])
+   *
+   * annotation key: [[zio.logging.loggerNameAnnotationKey]]
+   */
+  def loggerName(value: String): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+    ZIOAspect.annotated(loggerNameAnnotationKey, value)
 
   def console(
     format: LogFormat = LogFormat.colored,

--- a/docs/jpl.md
+++ b/docs/jpl.md
@@ -24,7 +24,7 @@ val logger = Runtime.removeDefaultLoggers >>> JPL.jpl
 Default `JPL` logger setup:
 * logger name (by default)  is extracted from `zio.Trace`
     * for example, trace `zio.logging.example.JplSimpleApp.run(JplSimpleApp.scala:17)` will have `zio.logging.example.JplSimpleApp` as logger name
-    * NOTE: custom logger name may be set by `JPL.loggerName` aspect
+    * NOTE: custom logger name may be set by `zio.logging.loggerName` aspect
 * all annotations (logger name annotation is excluded) are placed at the beginning of log message
 * cause is logged as throwable
 
@@ -33,7 +33,7 @@ See also [LogFormat and LogAppender](formatting-log-records.md#logformat-and-log
 Custom logger name set by aspect:
 
 ```scala
-ZIO.logInfo("Starting user operation") @@ JPL.loggerName("zio.logging.example.UserOperation")
+ZIO.logInfo("Starting user operation") @@ zio.logging.loggerName("zio.logging.example.UserOperation")
 ```
 
 
@@ -70,7 +70,7 @@ object JplSimpleApp extends ZIOAppDefault {
             ZIO.sleep(500.millis) *>
             ZIO.logInfo("Stopping user operation")
         } @@ ZIOAspect.annotated("user", uId.toString)
-      } @@ LogAnnotation.TraceId(traceId) @@ JPL.loggerName("zio.logging.example.UserOperation")
+      } @@ LogAnnotation.TraceId(traceId) @@ zio.logging.loggerName("zio.logging.example.UserOperation")
       _       <- ZIO.logInfo("Done")
     } yield ExitCode.success
 

--- a/docs/log-filter.md
+++ b/docs/log-filter.md
@@ -22,6 +22,6 @@ val filter = LogFilter.logLevelByName(
 
 will use the `Debug` log level for everything except for log events with the logger name
 prefixed by either `List("io", "netty")` or `List("io", "grpc", "netty")`.
-Logger name is extracted from `zio.Trace`.
+Logger name is extracted from log annotation or `zio.Trace`.
 
 `LogFilter.filter` returns a version of `zio.ZLogger` that only logs messages when this filter is satisfied.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -12,7 +12,8 @@ const sidebars = {
         'console-logger',
         'jpl',
         'slf4j',
-        'slf4j-bridge',
+        'slf4j1-bridge',
+        'slf4j2-bridge',
         'metrics',
         'testing'
       ]

--- a/docs/slf4j.md
+++ b/docs/slf4j.md
@@ -22,7 +22,7 @@ val logger = Runtime.removeDefaultLoggers >>> SLF4J.slf4j
 Default `SLF4J` logger setup:
 * logger name (by default)  is extracted from `zio.Trace`
     * for example, trace `zio.logging.example.Slf4jSimpleApp.run(Slf4jSimpleApp.scala:17)` will have `zio.logging.example.Slf4jSimpleApp` as logger name
-    * NOTE: custom logger name may be set by `SLF4J.loggerName` aspect
+    * NOTE: custom logger name may be set by `zio.logging.loggerName` aspect
 * all annotations (logger name and log marker name annotations are excluded) are placed into MDC context
 * cause is logged as throwable
 
@@ -31,7 +31,7 @@ See also [LogFormat and LogAppender](formatting-log-records.md#logformat-and-log
 Custom logger name set by aspect:
 
 ```scala
-ZIO.logInfo("Starting user operation") @@ SLF4J.loggerName("zio.logging.example.UserOperation")
+ZIO.logInfo("Starting user operation") @@ zio.logging.loggerName("zio.logging.example.UserOperation")
 ```
 
 Log marker name set by aspect:
@@ -76,7 +76,7 @@ object Slf4jSimpleApp extends ZIOAppDefault {
             ZIO.sleep(500.millis) *>
             ZIO.logInfo("Stopping user operation")
         } @@ ZIOAspect.annotated("user", uId.toString)
-      } @@ LogAnnotation.TraceId(traceId) @@ SLF4J.loggerName("zio.logging.example.UserOperation")
+      } @@ LogAnnotation.TraceId(traceId) @@ zio.logging.loggerName("zio.logging.example.UserOperation")
       _       <- ZIO.logInfo("Done")
     } yield ExitCode.success
 

--- a/docs/slf4j1-bridge.md
+++ b/docs/slf4j1-bridge.md
@@ -1,22 +1,13 @@
 ---
-id: slf4j-bridge
-title: "SLF4J bridge"
+id: slf4j1-bridge
+title: "SLF4J v1 bridge"
 ---
 
-It is possible to use `zio-logging` for SLF4J loggers, usually third-party non-ZIO libraries. To do so, import
-
-* the `zio-logging-slf4j-bridge` module for SLF4J v1:
+It is possible to use `zio-logging` for SLF4J loggers, usually third-party non-ZIO libraries. To do so, import the `zio-logging-slf4j-bridge` module for SLF4J v1:
 
 ```scala
 libraryDependencies += "dev.zio" %% "zio-logging-slf4j-bridge" % "@VERSION@"
 ```
-
-* the `zio-logging-slf4j2-bridge` module for [SLF4J v2](https://www.slf4j.org/faq.html#changesInVersion200) (using JDK9+ module system ([JPMS](http://openjdk.java.net/projects/jigsaw/spec/)))
-
-```scala
-libraryDependencies += "dev.zio" %% "zio-logging-slf4j2-bridge" % "@VERSION@"
-```
-
 
 and use the `Slf4jBridge.initialize` layer when setting up logging:
 

--- a/docs/slf4j2-bridge.md
+++ b/docs/slf4j2-bridge.md
@@ -1,0 +1,102 @@
+---
+id: slf4j2-bridge
+title: "SLF4J v2 bridge"
+---
+
+It is possible to use `zio-logging` for SLF4J loggers, usually third-party non-ZIO libraries. To do so, import  the `zio-logging-slf4j2-bridge` module for [SLF4J v2](https://www.slf4j.org/faq.html#changesInVersion200) (using JDK9+ module system ([JPMS](http://openjdk.java.net/projects/jigsaw/spec/)))
+
+```scala
+libraryDependencies += "dev.zio" %% "zio-logging-slf4j2-bridge" % "@VERSION@"
+```
+
+and use the `Slf4jBridge.initialize` layer when setting up logging:
+
+```scala
+import zio.logging.slf4j.Slf4jBridge
+
+program.provideCustom(Slf4jBridge.initialize)
+```
+
+<br/>
+
+SLF4J logger name is stored in log annotation with key `logger_name` (`zio.logging.loggerNameAnnotationKey`), following log format
+
+```scala
+import zio.logging.slf4j.Slf4jBridge
+import zio.logging.LoggerNameExtractor
+
+val loggerName = LoggerNameExtractor.loggerNameAnnotationOrTrace
+val loggerNameFormat = loggerName.toLogFormat()
+```
+may be used to get logger name from log annotation or ZIO Trace. 
+
+This logger name extractor is used by default in log filter, which applying log filtering by defined logger name and level:
+
+```scala
+val logFilter: LogFilter[String] = LogFilter.logLevelByName(
+  LogLevel.Info,
+  "zio.logging.slf4j" -> LogLevel.Debug,
+  "SLF4J-LOGGER"      -> LogLevel.Warning
+)
+```
+
+<br/>
+
+SLF4J bridge with custom logger can be setup:
+
+```scala
+import zio.logging.slf4j.Slf4jBridge
+
+val logger = Runtime.removeDefaultLoggers >>> zio.logging.consoleJson(LogFormat.default, LogLevel.Debug) >+> Slf4jBridge.initialize
+```
+
+<br/>
+
+**NOTE** You should either use `zio-logging-slf4j` to send all ZIO logs to an SLF4j provider (such as logback, log4j etc) OR `zio-logging-slf4j-bridge` to send all SLF4j logs to
+ZIO logging. Enabling both causes circular logging and makes no sense.
+
+
+## Examples
+
+### SLF4J bridge with JSON console logger
+
+[//]: # (TODO: make snippet type-checked using mdoc)
+
+```scala
+package zio.logging.slf4j.bridge
+
+import zio.logging.{ LogFilter, LogFormat, LoggerNameExtractor, consoleJson }
+import zio.{ ExitCode, LogLevel, Runtime, Scope, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer }
+
+object Slf4jBridgeExampleApp extends ZIOAppDefault {
+
+  private val slf4jLogger = org.slf4j.LoggerFactory.getLogger("SLF4J-LOGGER")
+
+  private val logFilter: LogFilter[String] = LogFilter.logLevelByName(
+    LogLevel.Info,
+    "zio.logging.slf4j" -> LogLevel.Debug,
+    "SLF4J-LOGGER"      -> LogLevel.Warning
+  )
+
+  override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] =
+    Runtime.removeDefaultLoggers >>> consoleJson(
+      LogFormat.label("name", LoggerNameExtractor.loggerNameAnnotationOrTrace.toLogFormat()) + LogFormat.default,
+      logFilter
+    ) >+> Slf4jBridge.initialize
+
+  override def run: ZIO[Scope, Any, ExitCode] =
+    for {
+      _ <- ZIO.logInfo("Start")
+      _ <- ZIO.succeed(slf4jLogger.warn("Test {}!", "WARNING"))
+      _ <- ZIO.logDebug("Done")
+    } yield ExitCode.success
+
+}
+```
+
+Expected Console Output:
+```
+{"name":"zio.logging.slf4j.bridge.Slf4jBridgeExampleApp","timestamp":"2023-01-07T18:25:40.397593+01:00","level":"DEBUG","thread":"zio-fiber-4","message":"Start"}
+{"name":"SLF4J-LOGGER","timestamp":"2023-01-07T18:25:40.416612+01:00","level":"WARN","thread":"zio-fiber-6","message":"Test WARNING!"}
+{"name":"zio.logging.slf4j.bridge.Slf4jBridgeExampleApp","timestamp":"2023-01-07T18:25:40.42043+01:00 ","level":"INFO","thread":"zio-fiber-4","message":"Done"}
+```

--- a/examples/src/main/scala/zio/logging/example/JplSimpleApp.scala
+++ b/examples/src/main/scala/zio/logging/example/JplSimpleApp.scala
@@ -37,7 +37,7 @@ object JplSimpleApp extends ZIOAppDefault {
                        ZIO.sleep(500.millis) *>
                        ZIO.logInfo("Stopping user operation")
                    } @@ ZIOAspect.annotated("user", uId.toString)
-                 } @@ LogAnnotation.TraceId(traceId) @@ JPL.loggerName("zio.logging.example.UserOperation")
+                 } @@ LogAnnotation.TraceId(traceId) @@ zio.logging.loggerName("zio.logging.example.UserOperation")
       _       <- ZIO.logInfo("Done")
     } yield ExitCode.success
 

--- a/examples/src/main/scala/zio/logging/example/Slf4jSimpleApp.scala
+++ b/examples/src/main/scala/zio/logging/example/Slf4jSimpleApp.scala
@@ -38,7 +38,7 @@ object Slf4jSimpleApp extends ZIOAppDefault {
                        ZIO.sleep(500.millis) *>
                        ZIO.logInfo("Stopping user operation")
                    } @@ ZIOAspect.annotated("user", uId.toString)
-                 } @@ LogAnnotation.TraceId(traceId) @@ SLF4J.loggerName("zio.logging.example.UserOperation")
+                 } @@ LogAnnotation.TraceId(traceId) @@ logging.loggerName("zio.logging.example.UserOperation")
       _       <- ZIO.logInfo("Done")
     } yield ExitCode.success
 

--- a/jpl/src/main/scala/zio/logging/backend/JPL.scala
+++ b/jpl/src/main/scala/zio/logging/backend/JPL.scala
@@ -48,7 +48,7 @@ object JPL {
   /**
    * log aspect annotation key for JPL logger name
    */
-  @deprecated
+  @deprecated("use zio.logging.loggerNameAnnotationKey", "2.1.8")
   val loggerNameAnnotationKey = "jpl_logger_name"
 
   /**
@@ -64,7 +64,7 @@ object JPL {
    *
    * annotation key: [[JPL.loggerNameAnnotationKey]]
    */
-  @deprecated
+  @deprecated("use zio.logging.loggerName", "2.1.8")
   def loggerName(value: String): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
     ZIOAspect.annotated(loggerNameAnnotationKey, value)
 

--- a/jpl/src/main/scala/zio/logging/backend/JPL.scala
+++ b/jpl/src/main/scala/zio/logging/backend/JPL.scala
@@ -17,7 +17,20 @@ package zio.logging.backend
 
 import zio.logging.internal.LogAppender
 import zio.logging.{ LogFormat, LoggerNameExtractor }
-import zio.{ Cause, FiberFailure, FiberId, FiberRefs, LogLevel, LogSpan, Runtime, Trace, ZIOAspect, ZLayer, ZLogger }
+import zio.{
+  Cause,
+  FiberFailure,
+  FiberId,
+  FiberRefs,
+  LogLevel,
+  LogSpan,
+  Runtime,
+  Trace,
+  ZIOAspect,
+  ZLayer,
+  ZLogger,
+  logging
+}
 
 object JPL {
 
@@ -35,19 +48,23 @@ object JPL {
   /**
    * log aspect annotation key for JPL logger name
    */
+  @deprecated
   val loggerNameAnnotationKey = "jpl_logger_name"
 
   /**
    * default log format for JPL logger
    */
   val logFormatDefault: LogFormat =
-    LogFormat.allAnnotations(excludeKeys = Set(loggerNameAnnotationKey)) + LogFormat.line + LogFormat.cause
+    LogFormat.allAnnotations(excludeKeys =
+      Set(loggerNameAnnotationKey, logging.loggerNameAnnotationKey)
+    ) + LogFormat.line + LogFormat.cause
 
   /**
    * JPL logger name aspect, by this aspect is possible to change default logger name (default logger name is extracted from [[Trace]])
    *
    * annotation key: [[JPL.loggerNameAnnotationKey]]
    */
+  @deprecated
   def loggerName(value: String): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
     ZIOAspect.annotated(loggerNameAnnotationKey, value)
 
@@ -137,7 +154,10 @@ object JPL {
         spans: List[LogSpan],
         annotations: Map[String, String]
       ): Unit = {
-        val jpLoggerName = annotations.getOrElse(loggerNameAnnotationKey, loggerName(trace))
+        val jpLoggerName = annotations.getOrElse(
+          loggerNameAnnotationKey,
+          annotations.getOrElse(zio.logging.loggerNameAnnotationKey, loggerName(trace))
+        )
         val jpLogger     = getJPLogger(jpLoggerName)
         if (isLogLevelEnabled(jpLogger, logLevel)) {
           val appender = logAppender(jpLogger, logLevel)

--- a/jpl/src/main/scala/zio/logging/backend/JPL.scala
+++ b/jpl/src/main/scala/zio/logging/backend/JPL.scala
@@ -56,7 +56,7 @@ object JPL {
    */
   val logFormatDefault: LogFormat =
     LogFormat.allAnnotations(excludeKeys =
-      Set(loggerNameAnnotationKey, logging.loggerNameAnnotationKey)
+      Set(JPL.loggerNameAnnotationKey, logging.loggerNameAnnotationKey)
     ) + LogFormat.line + LogFormat.cause
 
   /**
@@ -155,7 +155,7 @@ object JPL {
         annotations: Map[String, String]
       ): Unit = {
         val jpLoggerName = annotations.getOrElse(
-          loggerNameAnnotationKey,
+          JPL.loggerNameAnnotationKey,
           annotations.getOrElse(zio.logging.loggerNameAnnotationKey, loggerName(trace))
         )
         val jpLogger     = getJPLogger(jpLoggerName)

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -36,13 +36,16 @@ object BuildHelper {
     "UTF-8",
     "-feature",
     "-unchecked"
-  ) ++ {
-    if (sys.env.contains("CI")) {
-      Seq("-Xfatal-warnings")
-    } else {
-      Nil // to enable Scalafix locally
+  )
+  /* enable when we cleanup deprecation in next major release
+    ++ {
+      if (sys.env.contains("CI")) {
+        Seq("-Xfatal-warnings")
+      } else {
+        Nil // to enable Scalafix locally
+      }
     }
-  }
+   */
 
   private val std2xOptions = Seq(
     "-language:higherKinds",

--- a/slf4j-bridge/src/main/scala-2/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala-2/org/slf4j/impl/ZioLogger.scala
@@ -16,14 +16,13 @@
 package org.slf4j.impl
 
 import org.slf4j.helpers.{ MessageFormatter, ZioLoggerBase }
-import zio.logging.slf4j.bridge.Slf4jBridge
 import zio.{ Cause, ZIO }
 
 class ZioLogger(name: String, factory: ZioLoggerFactory) extends ZioLoggerBase(name) {
 
   private def run(f: ZIO[Any, Nothing, Unit]): Unit =
     factory.run {
-      ZIO.logSpan(name)(ZIO.logAnnotate(Slf4jBridge.loggerNameAnnotationKey, name)(f))
+      ZIO.logSpan(name)(ZIO.logAnnotate(factory.nameAnnotationKey, name)(f))
     }
 
   override def isTraceEnabled: Boolean = true

--- a/slf4j-bridge/src/main/scala-3/org/slf4j/impl/ZioLogger.scala
+++ b/slf4j-bridge/src/main/scala-3/org/slf4j/impl/ZioLogger.scala
@@ -17,13 +17,12 @@ package org.slf4j.impl
 
 import org.slf4j.helpers.{ MessageFormatter, ZioLoggerBase }
 import zio.{ Cause, ZIO }
-import zio.logging.slf4j.bridge.Slf4jBridge
 
 class ZioLogger(name: String, factory: ZioLoggerFactory) extends ZioLoggerBase(name) {
 
   private def run(f: ZIO[Any, Nothing, Unit]): Unit =
     factory.run {
-      ZIO.logSpan(name)(ZIO.logAnnotate(Slf4jBridge.loggerNameAnnotationKey, name)(f))
+      ZIO.logSpan(name)(ZIO.logAnnotate(factory.nameAnnotationKey, name)(f))
     }
 
   override def isTraceEnabled: Boolean = true

--- a/slf4j-bridge/src/main/scala/org/slf4j/impl/ZioLoggerFactory.scala
+++ b/slf4j-bridge/src/main/scala/org/slf4j/impl/ZioLoggerFactory.scala
@@ -18,16 +18,27 @@ package org.slf4j.impl
 import com.github.ghik.silencer.silent
 import org.slf4j.{ ILoggerFactory, Logger }
 import zio.ZIO
+import zio.logging.slf4j.bridge.Slf4jBridge
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.jdk.CollectionConverters._
 
 class ZioLoggerFactory extends ILoggerFactory {
   private var runtime: zio.Runtime[Any] = null
+  private var annotationKey: String     = Slf4jBridge.loggerNameAnnotationKey
   private val loggers                   = new ConcurrentHashMap[String, Logger]().asScala: @silent("JavaConverters")
 
   def attachRuntime(runtime: zio.Runtime[Any]): Unit =
     this.runtime = runtime
+
+  def setNameAnnotationKey(annotationKey: String): Unit = {
+    if (annotationKey == null) {
+      throw new IllegalArgumentException("Name annotation key is required")
+    }
+    this.annotationKey = annotationKey
+  }
+
+  private[impl] def nameAnnotationKey = annotationKey
 
   private[impl] def run(f: ZIO[Any, Nothing, Any]): Unit =
     if (runtime != null) {
@@ -42,8 +53,25 @@ class ZioLoggerFactory extends ILoggerFactory {
 }
 
 object ZioLoggerFactory {
+
+  /**
+   * initialize logger factory
+   */
   def initialize(runtime: zio.Runtime[Any]): Unit =
-    StaticLoggerBinder.getSingleton.getLoggerFactory
+    initialize(runtime, zio.logging.loggerNameAnnotationKey)
+
+  /**
+   * initialize logger factory, where custom annotation key for logger name may be provided
+   * this is to achieve backward compatibility where [[Slf4jBridge.loggerNameAnnotationKey]] was used
+   *
+   * NOTE: this feature may be removed in future releases
+   */
+  def initialize(runtime: zio.Runtime[Any], nameAnnotationKey: String): Unit = {
+    val factory = StaticLoggerBinder.getSingleton.getLoggerFactory
       .asInstanceOf[ZioLoggerFactory]
-      .attachRuntime(runtime)
+
+    factory.attachRuntime(runtime)
+    factory.setNameAnnotationKey(nameAnnotationKey)
+  }
+
 }

--- a/slf4j-bridge/src/main/scala/zio/logging/slf4j/bridge/Slf4jBridge.scala
+++ b/slf4j-bridge/src/main/scala/zio/logging/slf4j/bridge/Slf4jBridge.scala
@@ -20,13 +20,29 @@ import zio.{ ZIO, ZLayer }
 
 object Slf4jBridge {
 
+  /**
+   * log annotation key for slf4j logger name
+   */
+  @deprecated("use zio.logging.loggerNameAnnotationKey", "2.1.8")
   val loggerNameAnnotationKey: String = "slf4j_logger_name"
 
+  /**
+   * initialize SLF4J bridge
+   */
   def initialize: ZLayer[Any, Nothing, Unit] =
+    initialize(zio.logging.loggerNameAnnotationKey)
+
+  /**
+   * initialize SLF4J bridge, where custom annotation key for logger name may be provided
+   * this is to achieve backward compatibility where [[Slf4jBridge.loggerNameAnnotationKey]] was used
+   *
+   * NOTE: this feature may be removed in future releases
+   */
+  def initialize(nameAnnotationKey: String): ZLayer[Any, Nothing, Unit] =
     ZLayer {
       ZIO.runtime[Any].flatMap { runtime =>
         ZIO.succeed {
-          ZioLoggerFactory.initialize(runtime)
+          ZioLoggerFactory.initialize(runtime, nameAnnotationKey)
         }
       }
     }

--- a/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeExampleApp.scala
+++ b/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeExampleApp.scala
@@ -7,18 +7,15 @@ object Slf4jBridgeExampleApp extends ZIOAppDefault {
 
   private val slf4jLogger = org.slf4j.LoggerFactory.getLogger("SLF4J-LOGGER")
 
-  private val loggerName = LoggerNameExtractor.annotationOrTrace(Slf4jBridge.loggerNameAnnotationKey)
-
-  private val logFilter: LogFilter[String] = LogFilter.logLevelByGroup(
+  private val logFilter: LogFilter[String] = LogFilter.logLevelByName(
     LogLevel.Info,
-    loggerName.toLogGroup(),
     "zio.logging.slf4j" -> LogLevel.Debug,
     "SLF4J-LOGGER"      -> LogLevel.Warning
   )
 
   override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] =
     Runtime.removeDefaultLoggers >>> consoleJson(
-      LogFormat.label("name", loggerName.toLogFormat()) + LogFormat.default,
+      LogFormat.label("name", LoggerNameExtractor.loggerNameAnnotationOrTrace.toLogFormat()) + LogFormat.default,
       logFilter
     ) >+> Slf4jBridge.initialize
 

--- a/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
+++ b/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
@@ -17,7 +17,7 @@ object Slf4jBridgeSpec extends ZIOSpecDefault {
 
   override def spec =
     suite("Slf4jBridge")(
-      test("logs through slf4j") {
+      test("logs through slf4j - leggacy logger name annotation key") {
         val testFailure = new RuntimeException("test error")
         for {
           _      <- (for {
@@ -85,16 +85,85 @@ object Slf4jBridgeSpec extends ZIOSpecDefault {
             )
           )
         )
-      },
+      }.provide(Slf4jBridge.initialize(Slf4jBridge.loggerNameAnnotationKey)),
       test("Implements Logger#getName") {
         for {
           logger <- ZIO.attempt(org.slf4j.LoggerFactory.getLogger("zio.test.logger"))
         } yield assertTrue(logger.getName == "zio.test.logger")
-      },
+      }.provide(Slf4jBridge.initialize),
       test("implements MarkerFactoryBinder") {
         for {
           markerFactory <- ZIO.attempt(MarkerFactory.getIMarkerFactory)
         } yield assertTrue(markerFactory.eq(StaticMarkerBinder.getSingleton.getMarkerFactory))
-      }
-    ).provide(Slf4jBridge.initialize) @@ TestAspect.sequential
+      }.provide(Slf4jBridge.initialize),
+      test("logs through slf4j") {
+        val testFailure = new RuntimeException("test error")
+        for {
+          _      <- (for {
+                      logger <- ZIO.attempt(org.slf4j.LoggerFactory.getLogger("test.logger"))
+                      _      <- ZIO.attempt(logger.debug("test debug message"))
+                      _      <- ZIO.attempt(logger.warn("hello {}", "world"))
+                      _      <- ZIO.attempt(logger.warn("{}..{}..{} ... go!", "3", "2", "1"))
+                      _      <- ZIO.attempt(logger.warn("warn cause", testFailure))
+                      _      <- ZIO.attempt(logger.error("error", testFailure))
+                      _      <- ZIO.attempt(logger.error("error", null))
+                    } yield ()).exit
+          output <- ZTestLogger.logOutput
+          lines   = output.map { logEntry =>
+                      LogEntry(
+                        logEntry.spans.map(_.label),
+                        logEntry.logLevel,
+                        logEntry.annotations,
+                        logEntry.message(),
+                        logEntry.cause
+                      )
+                    }
+        } yield assertTrue(
+          lines == Chunk(
+            LogEntry(
+              List("test.logger"),
+              LogLevel.Debug,
+              Map(zio.logging.loggerNameAnnotationKey -> "test.logger"),
+              "test debug message",
+              Cause.empty
+            ),
+            LogEntry(
+              List("test.logger"),
+              LogLevel.Warning,
+              Map(zio.logging.loggerNameAnnotationKey -> "test.logger"),
+              "hello world",
+              Cause.empty
+            ),
+            LogEntry(
+              List("test.logger"),
+              LogLevel.Warning,
+              Map(zio.logging.loggerNameAnnotationKey -> "test.logger"),
+              "3..2..1 ... go!",
+              Cause.empty
+            ),
+            LogEntry(
+              List("test.logger"),
+              LogLevel.Warning,
+              Map(zio.logging.loggerNameAnnotationKey -> "test.logger"),
+              "warn cause",
+              Cause.die(testFailure)
+            ),
+            LogEntry(
+              List("test.logger"),
+              LogLevel.Error,
+              Map(zio.logging.loggerNameAnnotationKey -> "test.logger"),
+              "error",
+              Cause.die(testFailure)
+            ),
+            LogEntry(
+              List("test.logger"),
+              LogLevel.Error,
+              Map(zio.logging.loggerNameAnnotationKey -> "test.logger"),
+              "error",
+              Cause.empty
+            )
+          )
+        )
+      }.provide(Slf4jBridge.initialize)
+    ) @@ TestAspect.sequential
 }

--- a/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
@@ -53,7 +53,7 @@ object SLF4J {
    */
   val logFormatDefault: LogFormat =
     LogFormat.allAnnotations(excludeKeys =
-      Set(loggerNameAnnotationKey, logMarkerNameAnnotationKey, logging.loggerNameAnnotationKey)
+      Set(SLF4J.loggerNameAnnotationKey, SLF4J.logMarkerNameAnnotationKey, logging.loggerNameAnnotationKey)
     ) + LogFormat.line + LogFormat.cause
 
   /**
@@ -263,11 +263,11 @@ object SLF4J {
         annotations: Map[String, String]
       ): Unit = {
         val slf4jLoggerName = annotations.getOrElse(
-          loggerNameAnnotationKey,
+          SLF4J.loggerNameAnnotationKey,
           annotations.getOrElse(logging.loggerNameAnnotationKey, loggerName(trace))
         )
         val slf4jLogger     = LoggerFactory.getLogger(slf4jLoggerName)
-        val slf4jMarkerName = annotations.get(logMarkerNameAnnotationKey)
+        val slf4jMarkerName = annotations.get(SLF4J.logMarkerNameAnnotationKey)
         val slf4jMarker     = slf4jMarkerName.map(n => MarkerFactory.getMarker(n))
         if (isLogLevelEnabled(slf4jLogger, slf4jMarker, logLevel)) {
           val appender = logAppender(slf4jLogger, slf4jMarker, logLevel)

--- a/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
@@ -40,7 +40,7 @@ object SLF4J {
   /**
    * log aspect annotation key for slf4j logger name
    */
-  @deprecated
+  @deprecated("use zio.logging.loggerNameAnnotationKey", "2.1.8")
   val loggerNameAnnotationKey = "slf4j_logger_name"
 
   /**
@@ -61,7 +61,7 @@ object SLF4J {
    *
    * annotation key: [[SLF4J.loggerNameAnnotationKey]]
    */
-  @deprecated
+  @deprecated("use zio.logging.loggerName", "2.1.8")
   def loggerName(value: String): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
     ZIOAspect.annotated(loggerNameAnnotationKey, value)
 

--- a/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
@@ -18,7 +18,20 @@ package zio.logging.backend
 import org.slf4j.{ Logger, LoggerFactory, MDC, Marker, MarkerFactory }
 import zio.logging.internal.LogAppender
 import zio.logging.{ LogFormat, LoggerNameExtractor }
-import zio.{ Cause, FiberFailure, FiberId, FiberRefs, LogLevel, LogSpan, Runtime, Trace, ZIOAspect, ZLayer, ZLogger }
+import zio.{
+  Cause,
+  FiberFailure,
+  FiberId,
+  FiberRefs,
+  LogLevel,
+  LogSpan,
+  Runtime,
+  Trace,
+  ZIOAspect,
+  ZLayer,
+  ZLogger,
+  logging
+}
 
 import java.util
 
@@ -27,6 +40,7 @@ object SLF4J {
   /**
    * log aspect annotation key for slf4j logger name
    */
+  @deprecated
   val loggerNameAnnotationKey = "slf4j_logger_name"
 
   /**
@@ -39,7 +53,7 @@ object SLF4J {
    */
   val logFormatDefault: LogFormat =
     LogFormat.allAnnotations(excludeKeys =
-      Set(loggerNameAnnotationKey, logMarkerNameAnnotationKey)
+      Set(loggerNameAnnotationKey, logMarkerNameAnnotationKey, logging.loggerNameAnnotationKey)
     ) + LogFormat.line + LogFormat.cause
 
   /**
@@ -47,6 +61,7 @@ object SLF4J {
    *
    * annotation key: [[SLF4J.loggerNameAnnotationKey]]
    */
+  @deprecated
   def loggerName(value: String): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
     ZIOAspect.annotated(loggerNameAnnotationKey, value)
 
@@ -247,7 +262,10 @@ object SLF4J {
         spans: List[LogSpan],
         annotations: Map[String, String]
       ): Unit = {
-        val slf4jLoggerName = annotations.getOrElse(loggerNameAnnotationKey, loggerName(trace))
+        val slf4jLoggerName = annotations.getOrElse(
+          loggerNameAnnotationKey,
+          annotations.getOrElse(logging.loggerNameAnnotationKey, loggerName(trace))
+        )
         val slf4jLogger     = LoggerFactory.getLogger(slf4jLoggerName)
         val slf4jMarkerName = annotations.get(logMarkerNameAnnotationKey)
         val slf4jMarker     = slf4jMarkerName.map(n => MarkerFactory.getMarker(n))

--- a/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
+++ b/slf4j/src/main/scala/zio/logging/slf4j/SLF4J.scala
@@ -38,13 +38,13 @@ import java.util
 object SLF4J {
 
   /**
-   * log aspect annotation key for slf4j logger name
+   * log annotation key for slf4j logger name
    */
   @deprecated("use zio.logging.loggerNameAnnotationKey", "2.1.8")
   val loggerNameAnnotationKey = "slf4j_logger_name"
 
   /**
-   * log aspect annotation key for slf4j marker name
+   * log annotation key for slf4j marker name
    */
   val logMarkerNameAnnotationKey = "slf4j_log_marker_name"
 

--- a/slf4j/src/test/scala/zio/logging/backend/SLF4JSpec.scala
+++ b/slf4j/src/test/scala/zio/logging/backend/SLF4JSpec.scala
@@ -114,7 +114,7 @@ object SLF4JSpec extends ZIOSpecDefault {
         )
       }
     }.provide(loggerTraceAnnotation),
-    test("log all annotations into MDC with custom logger name") {
+    test("log all annotations into MDC with custom logger name - legacy") {
       (startStop() @@ SLF4J.loggerName("my-logger")).map { case (traceId, users) =>
         val loggerOutput = TestAppender.logOutput
         startStopAssert(loggerOutput, "my-logger") && assert(loggerOutput.map(_.mdc.get(LogAnnotation.TraceId.name)))(
@@ -128,7 +128,21 @@ object SLF4JSpec extends ZIOSpecDefault {
         )
       }
     }.provide(loggerDefault),
-    test("logger name changes") {
+    test("log all annotations into MDC with custom logger name") {
+      (startStop() @@ logging.loggerName("my-logger")).map { case (traceId, users) =>
+        val loggerOutput = TestAppender.logOutput
+        startStopAssert(loggerOutput, "my-logger") && assert(loggerOutput.map(_.mdc.get(LogAnnotation.TraceId.name)))(
+          equalTo(
+            Chunk.fill(4)(Some(traceId.toString)) :+ None
+          )
+        ) && assert(loggerOutput.map(_.mdc.get("user")))(
+          equalTo(users.flatMap(u => Chunk.fill(2)(Some(u.toString))) :+ None)
+        ) && assert(loggerOutput.map(_.mdc.contains(logging.loggerNameAnnotationKey)))(
+          equalTo(Chunk.fill(5)(false))
+        )
+      }
+    }.provide(loggerDefault),
+    test("logger name changes - legacy logger name annotation") {
       val users = Chunk.fill(2)(UUID.randomUUID())
       for {
         traceId <- ZIO.succeed(UUID.randomUUID())
@@ -169,19 +183,69 @@ object SLF4JSpec extends ZIOSpecDefault {
         )
       }
     }.provide(loggerDefault),
+    test("logger name changes") {
+      val users = Chunk.fill(2)(UUID.randomUUID())
+      for {
+        traceId <- ZIO.succeed(UUID.randomUUID())
+        _        = TestAppender.reset()
+        _       <- ZIO.logInfo("Start") @@ logging.loggerName("root-logger")
+        _       <- ZIO.foreach(users) { uId =>
+                     {
+                       ZIO.logInfo("Starting user operation") *> ZIO.sleep(500.millis) *> ZIO.logInfo(
+                         "Stopping user operation"
+                       )
+                     } @@ ZIOAspect.annotated("user", uId.toString) @@ logging.loggerName("user-logger")
+                   } @@ LogAnnotation.TraceId(traceId) @@ logging.loggerName("user-root-logger")
+        _       <- ZIO.logInfo("Done") @@ logging.loggerName("root-logger")
+      } yield {
+        val loggerOutput = TestAppender.logOutput
+        assertTrue(loggerOutput.forall(_.logLevel == LogLevel.Info)) && assert(loggerOutput.map(_.message))(
+          equalTo(
+            Chunk(
+              "Start",
+              "Starting user operation",
+              "Stopping user operation",
+              "Starting user operation",
+              "Stopping user operation",
+              "Done"
+            )
+          )
+        ) && assert(loggerOutput.map(_.loggerName))(
+          equalTo(
+            Chunk(
+              "root-logger",
+              "user-logger",
+              "user-logger",
+              "user-logger",
+              "user-logger",
+              "root-logger"
+            )
+          )
+        )
+      }
+    }.provide(loggerDefault),
     test("log error with cause") {
       someError().map { _ =>
         val loggerOutput = TestAppender.logOutput
         someErrorAssert(loggerOutput) && assertTrue(loggerOutput(0).cause.exists(_.contains("input < 1")))
       }
     }.provide(loggerLineCause),
-    test("log error with cause with custom logger name") {
+    test("log error with cause with custom logger name - legacy") {
       (someError() @@ SLF4J.loggerName("my-logger")).map { _ =>
         val loggerOutput = TestAppender.logOutput
         someErrorAssert(loggerOutput, "my-logger") && assertTrue(
           loggerOutput(0).cause.exists(_.contains("input < 1"))
         ) &&
         assertTrue(!loggerOutput(0).mdc.contains(SLF4J.loggerNameAnnotationKey))
+      }
+    }.provide(loggerLineCause),
+    test("log error with cause with custom logger name") {
+      (someError() @@ logging.loggerName("my-logger")).map { _ =>
+        val loggerOutput = TestAppender.logOutput
+        someErrorAssert(loggerOutput, "my-logger") && assertTrue(
+          loggerOutput(0).cause.exists(_.contains("input < 1"))
+        ) &&
+        assertTrue(!loggerOutput(0).mdc.contains(logging.loggerNameAnnotationKey))
       }
     }.provide(loggerLineCause),
     test("log error without cause") {

--- a/slf4j2-bridge/src/main/scala/zio/logging/slf4j/bridge/Slf4jBridge.scala
+++ b/slf4j2-bridge/src/main/scala/zio/logging/slf4j/bridge/Slf4jBridge.scala
@@ -19,8 +19,6 @@ import zio.{ ZIO, ZLayer }
 
 object Slf4jBridge {
 
-  val loggerNameAnnotationKey: String = "slf4j_logger_name"
-
   def initialize: ZLayer[Any, Nothing, Unit] =
     ZLayer {
       ZIO.runtime[Any].flatMap { runtime =>

--- a/slf4j2-bridge/src/main/scala/zio/logging/slf4j/bridge/Slf4jBridge.scala
+++ b/slf4j2-bridge/src/main/scala/zio/logging/slf4j/bridge/Slf4jBridge.scala
@@ -19,6 +19,9 @@ import zio.{ ZIO, ZLayer }
 
 object Slf4jBridge {
 
+  /**
+   * initialize SLF4J bridge
+   */
   def initialize: ZLayer[Any, Nothing, Unit] =
     ZLayer {
       ZIO.runtime[Any].flatMap { runtime =>

--- a/slf4j2-bridge/src/main/scala/zio/logging/slf4j/bridge/ZioLoggerRuntime.scala
+++ b/slf4j2-bridge/src/main/scala/zio/logging/slf4j/bridge/ZioLoggerRuntime.scala
@@ -34,7 +34,7 @@ final class ZioLoggerRuntime(runtime: Runtime[Any]) extends LoggerRuntime {
       runtime.unsafe.run {
         val logLevel = ZioLoggerRuntime.logLevelMapping(level)
         ZIO.logSpan(name) {
-          ZIO.logAnnotate(Slf4jBridge.loggerNameAnnotationKey, name) {
+          ZIO.logAnnotate(zio.logging.loggerNameAnnotationKey, name) {
             ZIO.logLevel(logLevel) {
               lazy val msg = if (arguments != null) {
                 MessageFormatter.arrayFormat(messagePattern, arguments.toArray).getMessage

--- a/slf4j2-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeExampleApp.scala
+++ b/slf4j2-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeExampleApp.scala
@@ -7,18 +7,15 @@ object Slf4jBridgeExampleApp extends ZIOAppDefault {
 
   private val slf4jLogger = org.slf4j.LoggerFactory.getLogger("SLF4J-LOGGER")
 
-  private val loggerName = LoggerNameExtractor.annotationOrTrace(Slf4jBridge.loggerNameAnnotationKey)
-
-  private val logFilter: LogFilter[String] = LogFilter.logLevelByGroup(
+  private val logFilter: LogFilter[String] = LogFilter.logLevelByName(
     LogLevel.Info,
-    loggerName.toLogGroup(),
     "zio.logging.slf4j" -> LogLevel.Debug,
     "SLF4J-LOGGER"      -> LogLevel.Warning
   )
 
   override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] =
     Runtime.removeDefaultLoggers >>> consoleJson(
-      LogFormat.label("name", loggerName.toLogFormat()) + LogFormat.default,
+      LogFormat.label("name", LoggerNameExtractor.loggerNameAnnotationOrTrace.toLogFormat()) + LogFormat.default,
       logFilter
     ) >+> Slf4jBridge.initialize
 

--- a/slf4j2-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeExampleApp.scala
+++ b/slf4j2-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeExampleApp.scala
@@ -20,10 +20,10 @@ object Slf4jBridgeExampleApp extends ZIOAppDefault {
     ) >+> Slf4jBridge.initialize
 
   override def run: ZIO[Scope, Any, ExitCode] =
-    (for {
+    for {
       _ <- ZIO.logInfo("Start")
       _ <- ZIO.succeed(slf4jLogger.warn("Test {}!", "WARNING"))
       _ <- ZIO.logDebug("Done")
-    } yield ExitCode.success)
+    } yield ExitCode.success
 
 }

--- a/slf4j2-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
+++ b/slf4j2-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
@@ -42,42 +42,42 @@ object Slf4jBridgeSpec extends ZIOSpecDefault {
             LogEntry(
               List("test.logger"),
               LogLevel.Debug,
-              Map(Slf4jBridge.loggerNameAnnotationKey -> "test.logger"),
+              Map(zio.logging.loggerNameAnnotationKey -> "test.logger"),
               "test debug message",
               Cause.empty
             ),
             LogEntry(
               List("test.logger"),
               LogLevel.Warning,
-              Map(Slf4jBridge.loggerNameAnnotationKey -> "test.logger"),
+              Map(zio.logging.loggerNameAnnotationKey -> "test.logger"),
               "hello world",
               Cause.empty
             ),
             LogEntry(
               List("test.logger"),
               LogLevel.Warning,
-              Map(Slf4jBridge.loggerNameAnnotationKey -> "test.logger"),
+              Map(zio.logging.loggerNameAnnotationKey -> "test.logger"),
               "3..2..1 ... go!",
               Cause.empty
             ),
             LogEntry(
               List("test.logger"),
               LogLevel.Warning,
-              Map(Slf4jBridge.loggerNameAnnotationKey -> "test.logger"),
+              Map(zio.logging.loggerNameAnnotationKey -> "test.logger"),
               "warn cause",
               Cause.die(testFailure)
             ),
             LogEntry(
               List("test.logger"),
               LogLevel.Error,
-              Map(Slf4jBridge.loggerNameAnnotationKey -> "test.logger"),
+              Map(zio.logging.loggerNameAnnotationKey -> "test.logger"),
               "error",
               Cause.die(testFailure)
             ),
             LogEntry(
               List("test.logger"),
               LogLevel.Error,
-              Map(Slf4jBridge.loggerNameAnnotationKey -> "test.logger"),
+              Map(zio.logging.loggerNameAnnotationKey -> "test.logger"),
               "error",
               Cause.empty
             )


### PR DESCRIPTION
common logger name annotation

before we did not have logger name annotation in core module o zio-logging, however we have custom logger name annotations in other modules (jpl backend, slf4j backend, slf4j bridge), but they have module specific names,
main problem in this case is that, then it is require to do custom configuration of log format, or log filter as they differ

with common annotation we can do default behavior, which will use logger name annotation or trace, which should then do not require to do some custom code (or require less additional configuration in user application)

current custom log annotations were deprecated

implementation considerations:
- `loggerNameAnnotationKey` and `loggerName` aspect function were placed to zio.logging package object, we should consider, if we can not find better placement or solution how to define specific log annotation and aspects - this is partly complicated as we already also have zio core log annotations and also zio logging log annotations
