### PR TITLE
update zio to 1.0.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,8 @@ jobs:
         if: ${{ !startsWith(matrix.scala, '3.') }}
         run: sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
       - name: Run dotty tests
-        if: ${{ startsWith(matrix.scala, '3.') && matrix.platform == 'JVM' }}
-        run: sbt ++${{ matrix.scala }}! testJVM
+        if: ${{ startsWith(matrix.scala, '3.') }}
+        run: sbt ++${{ matrix.scala }} test${{ matrix.platform }}
       - name: Compile additional subprojects
         if: ${{ !startsWith(matrix.scala, '3.') }}
         run: sbt ++${{ matrix.scala }}! examples/compile docs/compile benchmarks/compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,13 @@ jobs:
         uses: coursier/cache-action@v6
       - name: Run tests
         if: ${{ !startsWith(matrix.scala, '3.') }}
-        run: sbt ++${{ matrix.scala }} test${{ matrix.platform }}
+        run: sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
       - name: Run dotty tests
         if: ${{ startsWith(matrix.scala, '3.') && matrix.platform == 'JVM' }}
-        run: sbt ++${{ matrix.scala }} testJVM
+        run: sbt ++${{ matrix.scala }}! testJVM
       - name: Compile additional subprojects
         if: ${{ !startsWith(matrix.scala, '3.') }}
-        run: sbt ++${{ matrix.scala }} examples/compile docs/compile benchmarks/compile
+        run: sbt ++${{ matrix.scala }}! examples/compile docs/compile benchmarks/compile
 
   ci:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.11.12', '2.12.15', '2.13.6', '3.0.2']
+        scala: ['2.11.12', '2.12.17', '2.13.10', '3.2.2']
         platform: ['JVM', 'JS']
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,14 +62,14 @@ jobs:
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
       - name: Run tests
-        if: ${{ !startsWith(matrix.scala, '3.0.') }}
-        run: sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
+        if: ${{ !startsWith(matrix.scala, '3.') }}
+        run: sbt ++${{ matrix.scala }} test${{ matrix.platform }}
       - name: Run dotty tests
-        if: ${{ startsWith(matrix.scala, '3.0.') && matrix.platform == 'JVM' }}
-        run: sbt ++${{ matrix.scala }}! testJVM
+        if: ${{ startsWith(matrix.scala, '3.') && matrix.platform == 'JVM' }}
+        run: sbt ++${{ matrix.scala }} testJVM
       - name: Compile additional subprojects
-        if: ${{ !startsWith(matrix.scala, '3.0.') }}
-        run: sbt ++${{ matrix.scala }}! examples/compile docs/compile benchmarks/compile
+        if: ${{ !startsWith(matrix.scala, '3.') }}
+        run: sbt ++${{ matrix.scala }} examples/compile docs/compile benchmarks/compile
 
   ci:
     runs-on: ubuntu-20.04

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ inThisBuild(
   )
 )
 
-val ZioVersion           = "1.0.12"
+val ZioVersion           = "1.0.18"
 val scalaJavaTimeVersion = "2.3.0"
 val slf4jVersion         = "1.7.33"
 

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val core    = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "dev.zio"                %%% "zio"                     % ZioVersion,
       "dev.zio"                %%% "zio-streams"             % ZioVersion,
-      "org.scala-lang.modules" %%% "scala-collection-compat" % "2.5.0",
+      ("org.scala-lang.modules" %%% "scala-collection-compat" % "2.9.0").cross(CrossVersion.for3Use2_13),
       "dev.zio"                %%% "zio-test"                % ZioVersion % Test,
       "dev.zio"                %%% "zio-test-sbt"            % ZioVersion % Test
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -50,11 +50,11 @@ lazy val core    = crossProject(JSPlatform, JVMPlatform)
   .settings(stdSettings("zio-logging"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"                %%% "zio"                     % ZioVersion,
-      "dev.zio"                %%% "zio-streams"             % ZioVersion,
+      "dev.zio"                 %%% "zio"                     % ZioVersion,
+      "dev.zio"                 %%% "zio-streams"             % ZioVersion,
       ("org.scala-lang.modules" %%% "scala-collection-compat" % "2.9.0").cross(CrossVersion.for3Use2_13),
-      "dev.zio"                %%% "zio-test"                % ZioVersion % Test,
-      "dev.zio"                %%% "zio-test-sbt"            % ZioVersion % Test
+      "dev.zio"                 %%% "zio-test"                % ZioVersion % Test,
+      "dev.zio"                 %%% "zio-test-sbt"            % ZioVersion % Test
     ),
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
   )
@@ -66,7 +66,9 @@ lazy val coreJVM = core.jvm
   .settings(dottySettings)
 lazy val coreJS  = core.js.settings(
   libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.3.0" % Test,
-  libraryDependencies += ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0").cross(CrossVersion.for3Use2_13) % Test,
+  libraryDependencies += ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0").cross(
+    CrossVersion.for3Use2_13
+  )                                            % Test
 )
 
 lazy val slf4j = project

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,8 @@ lazy val core    = crossProject(JSPlatform, JVMPlatform)
 lazy val coreJVM = core.jvm
   .settings(dottySettings)
 lazy val coreJS  = core.js.settings(
-  libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.3.0" % Test
+  libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.3.0" % Test,
+  libraryDependencies += ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0").cross(CrossVersion.for3Use2_13) % Test,
 )
 
 lazy val slf4j = project

--- a/core/shared/src/main/scala/zio/logging/LogAnnotation.scala
+++ b/core/shared/src/main/scala/zio/logging/LogAnnotation.scala
@@ -2,6 +2,7 @@ package zio.logging
 
 import zio.Cause
 
+import com.github.ghik.silencer.silent
 import java.time.OffsetDateTime
 import java.{ util => ju }
 import scala.reflect.ClassTag
@@ -40,6 +41,7 @@ object LogAnnotation {
    * If a value for the annotation is present, it will be rendered using the provided function. When
    * absent, it will be rendered as an empty string.
    */
+  @silent("evidence")
   def optional[A: ClassTag](name: String, render: A => String): LogAnnotation[Option[A]] =
     LogAnnotation(
       name = name,

--- a/core/shared/src/main/scala/zio/logging/LogAnnotation.scala
+++ b/core/shared/src/main/scala/zio/logging/LogAnnotation.scala
@@ -1,8 +1,8 @@
 package zio.logging
 
+import com.github.ghik.silencer.silent
 import zio.Cause
 
-import com.github.ghik.silencer.silent
 import java.time.OffsetDateTime
 import java.{ util => ju }
 import scala.reflect.ClassTag

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -24,7 +24,7 @@ object BuildHelper {
   val Scala211: String                      = versions("2.11")
   val Scala212: String                      = versions("2.12")
   val Scala213: String                      = versions("2.13")
-  val ScalaDotty: String                    = versions("3.0")
+  val ScalaDotty: String                    = versions("3.2")
 
   val SilencerVersion = "1.7.8"
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -26,7 +26,7 @@ object BuildHelper {
   val Scala213: String                      = versions("2.13")
   val ScalaDotty: String                    = versions("3.2")
 
-  val SilencerVersion = "1.7.8"
+  val SilencerVersion = "1.7.12"
 
   private val stdOptions = Seq(
     "-deprecation",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.5
+sbt.version = 1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.typesafe"                      % "sbt-mima-plugin"            
 addSbtPlugin("de.heikoseeberger"                 % "sbt-header"                    % "5.6.0")
 addSbtPlugin("org.portable-scala"                % "sbt-scala-native-crossproject" % "1.1.0")
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject"      % "1.1.0")
-addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "1.7.1")
+addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "1.12.0")
 addSbtPlugin("org.scala-native"                  % "sbt-scala-native"              % "0.4.1")
 addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                      % "2.2.24")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.4.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("ch.epfl.scala"                     % "sbt-bloop"                     % "1.4.12")
-addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"                  % "0.9.33")
+addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"                  % "0.10.4")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"                 % "0.10.0")
 addSbtPlugin("com.eed3si9n"                      % "sbt-unidoc"                    % "0.4.3")
 addSbtPlugin("com.github.sbt"                    % "sbt-ci-release"                % "1.5.10")


### PR DESCRIPTION
According to release notes of ZIO 1.0.18:

> All Scala 3 users and downstream libraries are advised to update to ZIO 1.0.18 or newer and release newly recompiled versions to avoid stale Tags generated by older versions of izumi-reflect from surfacing https://github.com/zio/zio/issues/7489 on Scala 3.