### PR TITLE
fix scala-collection-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,11 +50,11 @@ lazy val core    = crossProject(JSPlatform, JVMPlatform)
   .settings(stdSettings("zio-logging"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"                 %%% "zio"                     % ZioVersion,
-      "dev.zio"                 %%% "zio-streams"             % ZioVersion,
-      ("org.scala-lang.modules" %%% "scala-collection-compat" % "2.9.0").cross(CrossVersion.for3Use2_13),
-      "dev.zio"                 %%% "zio-test"                % ZioVersion % Test,
-      "dev.zio"                 %%% "zio-test-sbt"            % ZioVersion % Test
+      "dev.zio"                %%% "zio"                     % ZioVersion,
+      "dev.zio"                %%% "zio-streams"             % ZioVersion,
+      "org.scala-lang.modules" %%% "scala-collection-compat" % "2.5.0",
+      "dev.zio"                %%% "zio-test"                % ZioVersion % Test,
+      "dev.zio"                %%% "zio-test-sbt"            % ZioVersion % Test
     ),
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
   )


### PR DESCRIPTION
During ZIO update it was incorrectly assumed that conflict of suffixes `_2.13`, `_3` was related to `scala-collection-compat`. In fact, it was fixed by dropping `!` for sbt command for Scala 3. Current build is leading to build error in dependent projects.

```
[error] Modules were resolved with conflicting cross-version suffixes in ProjectRef(uri("file:/"), "root"):
[error]    org.scala-lang.modules:scala-collection-compat _2.13, _3
[error] java.lang.RuntimeException: Conflicting cross-version suffixes in: org.scala-lang.modules:scala-collection-compat
```

Workaround is:
```
("dev.zio" %% "zio-logging-slf4j" % "0.5.15").exclude("org.scala-lang.modules", "scala-collection-compat_2.13")
```