### PR TITLE
slf4j bridge - init lock

### DIFF
--- a/slf4j-bridge/src/main/scala/zio/logging/slf4j/bridge/Slf4jBridge.scala
+++ b/slf4j-bridge/src/main/scala/zio/logging/slf4j/bridge/Slf4jBridge.scala
@@ -52,7 +52,7 @@ object Slf4jBridge {
     ZLayer {
       for {
         runtime <- ZIO.runtime[Any]
-        _       <- initLock.withPermits(1) {
+        _       <- initLock.withPermit {
                      ZIO.succeed(ZioLoggerFactory.initialize(new ZioLoggerRuntime(runtime, nameAnnotationKey)))
                    }
       } yield ()

--- a/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
+++ b/slf4j-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
@@ -5,8 +5,6 @@ import org.slf4j.impl.StaticMarkerBinder
 import zio.test._
 import zio.{ Cause, Chunk, LogLevel, ZIO, ZIOAspect }
 
-import java.util.UUID
-
 object Slf4jBridgeSpec extends ZIOSpecDefault {
 
   final case class LogEntry(
@@ -20,15 +18,14 @@ object Slf4jBridgeSpec extends ZIOSpecDefault {
   override def spec =
     suite("Slf4jBridge")(
       test("parallel init") {
-        val uuids = List.fill(5)(UUID.randomUUID())
         for {
           _ <-
-            ZIO.foreachPar(uuids) { u =>
+            ZIO.foreachPar((1 to 5).toList) { _ =>
               ZIO
-                .succeed(org.slf4j.LoggerFactory.getLogger("SLF4J-LOGGER").warn("Test {} {}!", "WARNING", u.toString))
+                .succeed(org.slf4j.LoggerFactory.getLogger("SLF4J-LOGGER").warn("Test {}!", "WARNING"))
                 .provide(Slf4jBridge.initialize)
             }
-        } yield assertTrue(true)
+        } yield assertCompletes
       },
       test("logs through slf4j - legacy logger name annotation key") {
         val testFailure = new RuntimeException("test error")

--- a/slf4j2-bridge/src/main/scala/zio/logging/slf4j/bridge/Slf4jBridge.scala
+++ b/slf4j2-bridge/src/main/scala/zio/logging/slf4j/bridge/Slf4jBridge.scala
@@ -35,7 +35,7 @@ object Slf4jBridge {
     ZLayer {
       for {
         runtime <- ZIO.runtime[Any]
-        _       <- initLock.withPermits(1) {
+        _       <- initLock.withPermit {
                      ZIO.succeed(
                        org.slf4j.LoggerFactory
                          .getILoggerFactory()

--- a/slf4j2-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
+++ b/slf4j2-bridge/src/test/scala/zio/logging/slf4j/bridge/Slf4jBridgeSpec.scala
@@ -3,8 +3,6 @@ package zio.logging.slf4j.bridge
 import zio.test._
 import zio.{ Cause, Chunk, LogLevel, ZIO, ZIOAspect }
 
-import java.util.UUID
-
 object Slf4jBridgeSpec extends ZIOSpecDefault {
 
   final case class LogEntry(
@@ -18,15 +16,14 @@ object Slf4jBridgeSpec extends ZIOSpecDefault {
   override def spec =
     suite("Slf4jBridge")(
       test("parallel init") {
-        val uuids = List.fill(5)(UUID.randomUUID())
         for {
           _ <-
-            ZIO.foreachPar(uuids) { u =>
+            ZIO.foreachPar((1 to 5).toList) { _ =>
               ZIO
-                .succeed(org.slf4j.LoggerFactory.getLogger("SLF4J-LOGGER").warn("Test {} {}!", "WARNING", u.toString))
+                .succeed(org.slf4j.LoggerFactory.getLogger("SLF4J-LOGGER").warn("Test {}!", "WARNING"))
                 .provide(Slf4jBridge.initialize)
             }
-        } yield assertTrue(true)
+        } yield assertCompletes
       },
       test("logs through slf4j") {
         val testFailure = new RuntimeException("test error")


### PR DESCRIPTION

add init log for slf4j bridge
more like in case of zio app, where there is just one initialisation it is not issue

but in case of tests, and multiple parallel initialisations, it is making issues like:
```
- Slf4jBridge - parallel init
  Exception in thread "zio-fiber-91,78" java.lang.ClassCastException: class org.slf4j.helpers.SubstituteLoggerFactory cannot be cast to class zio.logging.slf4j.bridge.LoggerFactory (org.slf4j.helpers.SubstituteLoggerFactory and zio.logging.slf4j.bridge.LoggerFactory are in unnamed module of loader sbt.internal.LayeredClassLoader @3c6460fa)
  at zio.logging.slf4j.bridge.Slf4jBridge$.$anonfun$layer$3(Slf4jBridge.scala:43)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
  at zio.logging.slf4j.bridge.Slf4jBridge.layer(Slf4jBridge.scala:39)
  at zio.logging.slf4j.bridge.Slf4jBridge.layer(Slf4jBridge.scala:37)
  at zio.logging.slf4j.bridge.Slf4jBridgeSpec.spec(Slf4jBridgeSpec.scala:27)
  at zio.logging.slf4j.bridge.Slf4jBridgeSpec.spec(Slf4jBridgeSpec.scala:24)
  Exception in thread "zio-fiber-90,79" java.lang.ClassCastException: class org.slf4j.helpers.SubstituteLoggerFactory cannot be cast to class zio.logging.slf4j.bridge.LoggerFactory (org.slf4j.helpers.SubstituteLoggerFactory and zio.logging.slf4j.bridge.LoggerFactory are in unnamed module of loader sbt.internal.LayeredClassLoader @3c6460fa)
  at zio.logging.slf4j.bridge.Slf4jBridge$.$anonfun$layer$3(Slf4jBridge.scala:43)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
  at zio.logging.slf4j.bridge.Slf4jBridge.layer(Slf4jBridge.scala:39)
  at zio.logging.slf4j.bridge.Slf4jBridge.layer(Slf4jBridge.scala:37)
  at zio.logging.slf4j.bridge.Slf4jBridgeSpec.spec(Slf4jBridgeSpec.scala:27)
  at zio.logging.slf4j.bridge.Slf4jBridgeSpec.spec(Slf4jBridgeSpec.scala:24)
  Exception in thread "zio-fiber-87,80" java.lang.ClassCastException: class org.slf4j.helpers.SubstituteLoggerFactory cannot be cast to class zio.logging.slf4j.bridge.LoggerFactory (org.slf4j.helpers.SubstituteLoggerFactory and 
```