### PR TITLE
zio 2.1.1, removed java 8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
       fail-fast: false
       matrix:
         java:
-        - '8'
         - '11'
         - '17'
         scala:

--- a/build.sbt
+++ b/build.sbt
@@ -52,10 +52,12 @@ inThisBuild(
       ),
       Developer("justcoon", "Peter Kotula", "peto.kotula@yahoo.com", url("https://github.com/justcoon"))
     ),
-    zioVersion             := "2.0.22",
+    zioVersion             := "2.1.1",
     scala212               := "2.12.17",
     scala213               := "2.13.10",
-    scala3                 := "3.3.0"
+    scala3                 := "3.3.0",
+    javaPlatform           := "11",
+    javaPlatforms          := Seq("11", "17")
   )
 )
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -9,7 +9,7 @@ object Versions {
   val zioMetricsConnectorsVersion   = "2.3.1"
   val zioConfig                     = "4.0.2"
   val zioParser                     = "0.1.10"
-  val zioPrelude                    = "1.0.0-RC25"
+  val zioPrelude                    = "1.0.0-RC26"
   val zioHttp                       = "3.0.0-RC6"
   val log4jVersion                  = "2.23.1"
 }


### PR DESCRIPTION
fixes: #846

removed java 8 support, as zio 2.1.+ [require jdk 11](https://github.com/zio/zio-logging/actions/runs/9046652250/job/24857704028)

```
[error] java.lang.UnsupportedClassVersionError: zio/internal/MutableQueueFieldsPadding has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
[error] 	at java.lang.ClassLoader.defineClass1(Native Method)
[error] 	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
```