### PR TITLE
Add appendLoggerName aspect

### DIFF
--- a/core/jvm/src/test/scala/zio/logging/AppendLoggerNameSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/AppendLoggerNameSpec.scala
@@ -1,0 +1,19 @@
+package zio.logging
+
+import zio.test._
+import zio.logging.appendLoggerName
+import zio.FiberRef
+
+object AppendLoggerNameSpec extends ZIOSpecDefault {
+
+  val spec: Spec[Environment, Any] = suite("AppendLoggerNameSpec")(
+    test("appendLoggerName") {
+      for {
+        name <- FiberRef.currentLogAnnotations.get.map(annotations =>
+                  annotations.get(loggerNameAnnotationKey)
+                ) @@ appendLoggerName("logging") @@ appendLoggerName("zio")
+
+      } yield assertTrue(name == Some("zio.logging"))
+    }
+  )
+}

--- a/core/jvm/src/test/scala/zio/logging/AppendLoggerNameSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/AppendLoggerNameSpec.scala
@@ -1,8 +1,8 @@
 package zio.logging
 
-import zio.test._
-import zio.logging.appendLoggerName
 import zio.ZIO
+import zio.logging.appendLoggerName
+import zio.test._
 
 object AppendLoggerNameSpec extends ZIOSpecDefault {
 

--- a/core/jvm/src/test/scala/zio/logging/AppendLoggerNameSpec.scala
+++ b/core/jvm/src/test/scala/zio/logging/AppendLoggerNameSpec.scala
@@ -2,16 +2,16 @@ package zio.logging
 
 import zio.test._
 import zio.logging.appendLoggerName
-import zio.FiberRef
+import zio.ZIO
 
 object AppendLoggerNameSpec extends ZIOSpecDefault {
 
   val spec: Spec[Environment, Any] = suite("AppendLoggerNameSpec")(
     test("appendLoggerName") {
       for {
-        name <- FiberRef.currentLogAnnotations.get.map(annotations =>
-                  annotations.get(loggerNameAnnotationKey)
-                ) @@ appendLoggerName("logging") @@ appendLoggerName("zio")
+        name <- ZIO.logAnnotations.map(annotations => annotations.get(loggerNameAnnotationKey)) @@ appendLoggerName(
+                  "logging"
+                ) @@ appendLoggerName("zio")
 
       } yield assertTrue(name == Some("zio.logging"))
     }

--- a/core/shared/src/main/scala/zio/logging/package.scala
+++ b/core/shared/src/main/scala/zio/logging/package.scala
@@ -55,21 +55,29 @@ package object logging extends LoggerLayers {
     ZIOAspect.annotated(loggerNameAnnotationKey, value)
 
   /**
+   * Logger name aspect, by this aspect is possible to set logger name (in general, logger name is extracted from [[Trace]])
+   *
+   * annotation key: [[zio.logging.loggerNameAnnotationKey]]
+   */
+  def loggerName(fn: Option[String] => String): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+      def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+        for {
+          annotations      <- ZIO.logAnnotations
+          currentLoggerName = annotations.get(loggerNameAnnotationKey)
+          newLoggerName     = fn(currentLoggerName)
+          a                <- ZIO.logAnnotate(loggerNameAnnotationKey, newLoggerName)(zio)
+        } yield a
+    }
+
+  /**
    * Append logger name aspect, by which it is possible to append a logger name to the current logger name.
    * The new name is appended using a dot (.) as the delimiter.
    *
    * annotation key: [[zio.logging.loggerNameAnnotationKey]]
    */
   def appendLoggerName(value: String): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
-    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
-      def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-        for {
-          annotations      <- ZIO.logAnnotations
-          currentLoggerName = annotations.get(loggerNameAnnotationKey)
-          newLoggerName     = currentLoggerName.fold(value)(currentLoggerName => s"$currentLoggerName.$value")
-          a                <- ZIO.logAnnotate(loggerNameAnnotationKey, newLoggerName)(zio)
-        } yield a
-    }
+    loggerName(currentLoggerName => currentLoggerName.fold(value)(currentLoggerName => s"$currentLoggerName.$value"))
 
   implicit final class LogAnnotationZIOSyntax[R, E, A](private val self: ZIO[R, E, A]) {
     def logAnnotate[V: Tag](key: LogAnnotation[V], value: V): ZIO[R, E, A] =

--- a/core/shared/src/main/scala/zio/logging/package.scala
+++ b/core/shared/src/main/scala/zio/logging/package.scala
@@ -64,7 +64,7 @@ package object logging extends LoggerLayers {
     new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
       def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
         for {
-          annotations      <- FiberRef.currentLogAnnotations.get
+          annotations      <- ZIO.logAnnotations
           currentLoggerName = annotations.get(loggerNameAnnotationKey)
           newLoggerName     = currentLoggerName.fold(value)(currentLoggerName => s"$currentLoggerName.$value")
           a                <- ZIO.logAnnotate(loggerNameAnnotationKey, newLoggerName)(zio)


### PR DESCRIPTION
We are upgrading from ZIO 1, where the previous version of zio.logging appended the logger name to the existing logger name. In the new version, it replaces it. This PR suggests introducing a new aspect, appendLoggerName, to append a string to the existing logger name.

Our codebase relies on setting the logger name. For example, when our RPC framework receives an incoming message, we add the service name and method name to the logger name.